### PR TITLE
feat(diagnostics): add Androlog persistent release-safe event log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,3 +156,4 @@ When investigating protocol behaviour, message shapes, or backend fields, consul
 | Emoji picker, search, generated data files, JVM 64 KB chunk pattern | [docs/EMOJI.md](docs/EMOJI.md) |
 | Reactions lifecycle, storage, redaction path, `removeReaction` internals | [docs/REACTIONS.md](docs/REACTIONS.md) |
 | Element Call (WebView/WebRTC, call state, incoming banners, timeline narrator, widget protocol) | [docs/ELEMENT_CALL.md](docs/ELEMENT_CALL.md) |
+| Androlog (persistent release-safe event log, `Androlog(category, text)`, viewer screen) | [docs/ANDROLOG.md](docs/ANDROLOG.md) |

--- a/app/src/main/java/net/vrkknn/andromuks/Androlog.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/Androlog.kt
@@ -1,0 +1,143 @@
+package net.vrkknn.andromuks
+
+import android.content.Context
+import org.json.JSONArray
+
+/**
+ * Androlog — a lightweight, app-wide log for cherry-picked events that survive R8 stripping.
+ *
+ * Unlike [android.util.Log.d] (which R8 removes from release builds), Androlog entries are kept
+ * in memory and persisted to SharedPreferences so they can be reviewed on a dedicated Settings
+ * screen ("Androlog") and exported, in both debug and release builds.
+ *
+ * Call it from anywhere via the invoke operator:
+ *
+ * ```
+ * Androlog("Notifications", "Failed to download notification image: HTTP 404 Not found")
+ * ```
+ *
+ * or explicitly with [log]. Each entry records a timestamp, a caller-provided category, and the
+ * log text. The store is a process-wide singleton; it must be initialised once with an application
+ * Context (done in [AndromuksApplication.onCreate]) before entries can be persisted. Calls made
+ * before init are still kept in memory and flushed on the next [init].
+ */
+object Androlog {
+
+    private const val MAX_ENTRIES = 200
+    private const val PREFS_NAME = "AndromuksAndrologPrefs"
+    private const val PREFS_KEY = "androlog"
+
+    data class Entry(
+        val timestamp: Long,
+        val category: String,
+        val text: String
+    ) {
+        fun toJson(): org.json.JSONObject {
+            val json = org.json.JSONObject()
+            json.put("timestamp", timestamp)
+            json.put("category", category)
+            json.put("text", text)
+            return json
+        }
+
+        companion object {
+            fun fromJson(json: org.json.JSONObject): Entry {
+                return Entry(
+                    timestamp = json.getLong("timestamp"),
+                    category = json.optString("category"),
+                    text = json.optString("text")
+                )
+            }
+        }
+    }
+
+    private val lock = Any()
+    private val entries = mutableListOf<Entry>()
+    @Volatile private var appContext: Context? = null
+    @Volatile private var loaded = false
+
+    /**
+     * Initialise the persistent store. Safe to call multiple times; loads persisted entries the
+     * first time and flushes any entries logged before initialisation.
+     */
+    fun init(context: Context) {
+        appContext = context.applicationContext
+        if (!loaded) {
+            loadFromStorage()
+            loaded = true
+        }
+        // Flush anything that was logged before we had a context.
+        saveToStorage()
+    }
+
+    /** Add a log entry. Usage: `Androlog("Category", "message")`. */
+    operator fun invoke(category: String, text: String) = log(category, text)
+
+    fun log(category: String, text: String) {
+        val entry = Entry(
+            timestamp = System.currentTimeMillis(),
+            category = category,
+            text = text
+        )
+        synchronized(lock) {
+            entries.add(entry)
+            if (entries.size > MAX_ENTRIES) {
+                entries.removeAt(0)
+            }
+        }
+        // Mirror to logcat so it's also visible in a live dump (Log.i survives R8).
+        android.util.Log.i("Androlog", "[$category] $text")
+        saveToStorage()
+    }
+
+    fun getEntries(): List<Entry> = synchronized(lock) { entries.toList() }
+
+    fun clear() {
+        synchronized(lock) { entries.clear() }
+        saveToStorage()
+    }
+
+    private fun loadFromStorage() {
+        val ctx = appContext ?: return
+        try {
+            val prefs = ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val json = prefs.getString(PREFS_KEY, null) ?: return
+            val array = JSONArray(json)
+            synchronized(lock) {
+                val loadedEntries = ArrayList<Entry>(array.length())
+                for (i in 0 until array.length()) {
+                    loadedEntries.add(Entry.fromJson(array.getJSONObject(i)))
+                }
+                // Persisted entries come first, then anything logged before init.
+                val pending = entries.toList()
+                entries.clear()
+                entries.addAll(loadedEntries)
+                entries.addAll(pending)
+                if (entries.size > MAX_ENTRIES) {
+                    val kept = entries.takeLast(MAX_ENTRIES)
+                    entries.clear()
+                    entries.addAll(kept)
+                }
+            }
+        } catch (e: Exception) {
+            android.util.Log.e("Andromuks", "Androlog: Failed to load from storage", e)
+        }
+    }
+
+    private fun saveToStorage() {
+        val ctx = appContext ?: return
+        try {
+            val prefs = ctx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val array = JSONArray()
+            val toSave = synchronized(lock) {
+                if (entries.size > MAX_ENTRIES) entries.takeLast(MAX_ENTRIES).toList()
+                else entries.toList()
+            }
+            toSave.forEach { array.put(it.toJson()) }
+            // apply() not commit(): best-effort, no need to block the caller on fsync.
+            prefs.edit().putString(PREFS_KEY, array.toString()).apply()
+        } catch (e: Exception) {
+            android.util.Log.e("Andromuks", "Androlog: Failed to save to storage", e)
+        }
+    }
+}

--- a/app/src/main/java/net/vrkknn/andromuks/AndrologScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/AndrologScreen.kt
@@ -1,0 +1,201 @@
+@file:Suppress("DEPRECATION")
+
+package net.vrkknn.andromuks
+
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.*
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AndrologScreen(
+    navController: NavController
+) {
+    // refreshTrigger forces re-read of the in-memory log (e.g. after clearing).
+    var refreshTrigger by remember { mutableStateOf(0) }
+    val entries = remember(refreshTrigger) { Androlog.getEntries() }
+    val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val scope = rememberCoroutineScope()
+
+    val exportLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("text/plain")
+    ) { uri ->
+        if (uri == null) {
+            scope.launch { snackbarHostState.showSnackbar("Export cancelled") }
+            return@rememberLauncherForActivityResult
+        }
+        try {
+            val exportText = buildAndrologExportText(entries)
+            context.contentResolver.openOutputStream(uri)?.bufferedWriter()?.use { writer ->
+                writer.write(exportText)
+            }
+            scope.launch { snackbarHostState.showSnackbar("Androlog exported") }
+        } catch (e: Exception) {
+            scope.launch { snackbarHostState.showSnackbar("Failed to export Androlog") }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Androlog") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                },
+                actions = {
+                    IconButton(
+                        enabled = entries.isNotEmpty(),
+                        onClick = {
+                            Androlog.clear()
+                            refreshTrigger++
+                            scope.launch { snackbarHostState.showSnackbar("Androlog cleared") }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Delete,
+                            contentDescription = "Clear log"
+                        )
+                    }
+                    TextButton(
+                        enabled = entries.isNotEmpty(),
+                        onClick = {
+                            val stamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+                            exportLauncher.launch("andromuks_androlog_$stamp.txt")
+                        }
+                    ) {
+                        Text("Export")
+                    }
+                }
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            if (entries.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = "No Androlog entries yet",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        Text(
+                            text = "Cherry-picked events logged via Androlog(...) will appear here",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(entries.reversed()) { entry ->
+                        AndrologEntryCard(entry = entry)
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun buildAndrologExportText(entries: List<Androlog.Entry>): String {
+    val lineDateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+    val now = Date()
+    val builder = StringBuilder()
+
+    builder.append("Andromuks Androlog\n")
+    builder.append("Exported at: ${lineDateFormat.format(now)}\n")
+    builder.append("Total entries: ${entries.size}\n")
+    builder.append("\n")
+
+    entries.forEach { entry ->
+        val timestamp = lineDateFormat.format(Date(entry.timestamp))
+        builder.append("$timestamp | ${entry.category} | ${entry.text}\n")
+    }
+
+    return builder.toString()
+}
+
+@Composable
+fun AndrologEntryCard(entry: Androlog.Entry) {
+    val dateFormat = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+    val formattedTime = dateFormat.format(Date(entry.timestamp))
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = formattedTime,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                if (entry.category.isNotEmpty()) {
+                    Surface(
+                        color = MaterialTheme.colorScheme.primaryContainer,
+                        shape = MaterialTheme.shapes.small
+                    ) {
+                        Text(
+                            text = entry.category,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onPrimaryContainer,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                        )
+                    }
+                }
+            }
+
+            Text(
+                text = entry.text,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium
+            )
+        }
+    }
+}

--- a/app/src/main/java/net/vrkknn/andromuks/AndromuksApplication.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/AndromuksApplication.kt
@@ -52,6 +52,8 @@ class AndromuksApplication : Application() {
         // even before AppViewModel.updateAuthToken is called.
         ImageLoaderSingleton.initFromStorage(this)
         migrateLegacyImageCache()
+        // Initialise the Androlog store so cherry-picked events can be persisted/reviewed.
+        Androlog.init(this)
     }
 
     private fun prewarmSharedPreferences() {

--- a/app/src/main/java/net/vrkknn/andromuks/EnhancedNotificationDisplay.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/EnhancedNotificationDisplay.kt
@@ -979,8 +979,19 @@ class EnhancedNotificationDisplay(private val context: Context, private val home
                     // would be incorrectly overwritten with image data.
                     messageTimestamp = notificationData.timestamp ?: System.currentTimeMillis()
                 )
+            } else if (hasImage) {
+                // hasImage is true but we never resolved an HTTP URL to download from, so the
+                // Phase 2 worker is NOT enqueued and the notification stays text-only forever.
+                // This is the silent failure mode for "image notifications never update": the
+                // image URL was an unrecognized format, or mxcToHttpUrl returned null.
+                Androlog(
+                    "Notifications",
+                    "Room ${notificationData.roomId}: image notification will NOT be updated with the image — " +
+                        "could not resolve a download URL from image='${notificationData.image}' " +
+                        "(deferredHttpUrl=null, deferredMxcUrl=$deferredMxcUrl). Phase 2 worker not enqueued."
+                )
             }
-            
+
             // SHORTCUT OPTIMIZATION: Shortcuts already updated above when notification is shown
             // Using efficient single-room update via updateShortcutsFromSyncRooms
             

--- a/app/src/main/java/net/vrkknn/andromuks/MainActivity.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/MainActivity.kt
@@ -1753,6 +1753,11 @@ fun AppNavigation(
                 navController = navController
             )
         }
+        composable("androlog") {
+            AndrologScreen(
+                navController = navController
+            )
+        }
         composable(
             route = "mentions?roomId={roomId}",
             arguments = listOf(navArgument("roomId") {

--- a/app/src/main/java/net/vrkknn/andromuks/NotificationImageWorker.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/NotificationImageWorker.kt
@@ -133,6 +133,10 @@ class NotificationImageWorker(
         val existing = systemNm.activeNotifications.firstOrNull { it.id == notifId }
         if (existing == null) {
             if (BuildConfig.DEBUG) Log.d(TAG, "Notification for room $roomId was dismissed — skipping image update")
+            Androlog(
+                "Notifications",
+                "Room $roomId: image update skipped — notification no longer active (dismissed/marked read) before worker ran. eventId=$eventId"
+            )
             return Result.success()
         }
 
@@ -147,12 +151,26 @@ class NotificationImageWorker(
             }
         } catch (e: Exception) {
             Log.e(TAG, "Image download failed for room $roomId", e)
-            return if (runAttemptCount < 3) Result.retry() else Result.failure()
+            val willRetry = runAttemptCount < 3
+            Androlog(
+                "Notifications",
+                "Room $roomId: image download threw on attempt ${runAttemptCount + 1} — ${e.javaClass.simpleName}: ${e.message}. " +
+                    (if (willRetry) "Will retry; notification not yet updated." else "Giving up after $runAttemptCount attempts; notification will NOT be updated with the image.") +
+                    " url=$imageUrl"
+            )
+            return if (willRetry) Result.retry() else Result.failure()
         }
 
         if (imageFile == null || !imageFile.exists()) {
             Log.w(TAG, "Image file missing after download attempt for room $roomId")
-            return if (runAttemptCount < 3) Result.retry() else Result.failure()
+            val willRetry = runAttemptCount < 3
+            Androlog(
+                "Notifications",
+                "Room $roomId: image file missing after download attempt ${runAttemptCount + 1} (imageFile=${if (imageFile == null) "null" else "does-not-exist"}). " +
+                    (if (willRetry) "Will retry; notification not yet updated." else "Giving up after $runAttemptCount attempts; notification will NOT be updated with the image.") +
+                    " url=$imageUrl"
+            )
+            return if (willRetry) Result.retry() else Result.failure()
         }
 
         // 3. Wrap in a content:// URI that the notification subsystem can read.
@@ -164,6 +182,11 @@ class NotificationImageWorker(
             )
         } catch (e: Exception) {
             Log.e(TAG, "FileProvider URI creation failed for room $roomId", e)
+            Androlog(
+                "Notifications",
+                "Room $roomId: FileProvider URI creation failed — ${e.javaClass.simpleName}: ${e.message}. " +
+                    "Notification will NOT be updated with the image. file=${imageFile.absolutePath}"
+            )
             return Result.failure()
         }
 
@@ -181,11 +204,23 @@ class NotificationImageWorker(
         val existingStyle = MessagingStyle.extractMessagingStyleFromNotification(existing.notification)
         if (existingStyle == null) {
             Log.w(TAG, "Could not extract MessagingStyle for room $roomId")
+            Androlog(
+                "Notifications",
+                "Room $roomId: could not extract MessagingStyle from the active notification — " +
+                    "notification will NOT be updated with the image. eventId=$eventId"
+            )
             return Result.failure()
         }
 
         val messages = existingStyle.messages.toList()
-        if (messages.isEmpty()) return Result.failure()
+        if (messages.isEmpty()) {
+            Androlog(
+                "Notifications",
+                "Room $roomId: active notification's MessagingStyle had no messages to upgrade — " +
+                    "notification will NOT be updated with the image. eventId=$eventId"
+            )
+            return Result.failure()
+        }
 
         // 5. Rebuild MessagingStyle: find and upgrade the target message to an image version.
         //    We match by timestamp so that a newer text message that arrived between Phase 1
@@ -285,6 +320,10 @@ class NotificationImageWorker(
         }
 
         if (BuildConfig.DEBUG) Log.d(TAG, "Notification updated with image for room $roomId")
+        Androlog(
+            "Notifications",
+            "Room $roomId: notification successfully updated with image (ts=$messageTimestamp, mime=$mimeType)."
+        )
         return Result.success()
     }
 }

--- a/app/src/main/java/net/vrkknn/andromuks/SettingsScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/SettingsScreen.kt
@@ -519,6 +519,36 @@ fun SettingsScreen(
                 }
             }
 
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        text = "Androlog",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Text(
+                        text = "View cherry-picked events logged via Androlog(...). These are kept and persisted in both debug and release builds (unlike debug logcat output, which is stripped from release).",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    Button(
+                        onClick = { navController.navigate("androlog") },
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text("View Androlog")
+                    }
+                }
+            }
+
             // About Section
             Text(
                 text = "About",

--- a/docs/ANDROLOG.md
+++ b/docs/ANDROLOG.md
@@ -1,0 +1,62 @@
+# Androlog — persistent, release-safe event log
+
+`Androlog` is a lightweight, app-wide log for **cherry-picked events** that must survive into release builds. It exists because the project's R8 config (`app/proguard-rules.pro`) strips `Log.d`/`Log.v`/`Log.isLoggable` from release APKs — so the chatty debug diagnostics that are invaluable while developing are simply gone when a user hits a problem on a release build. Androlog entries are kept in memory and persisted to `SharedPreferences`, viewable on a dedicated Settings screen and exportable, in **both debug and release**.
+
+It is *not* a replacement for logcat. Use it sparingly, for the handful of events you actually want to inspect after the fact on a real device.
+
+## API
+
+`Androlog` is a process-wide singleton object (`app/src/main/java/net/vrkknn/andromuks/Androlog.kt`). Call it from anywhere via the invoke operator:
+
+```kotlin
+Androlog("Notifications", "Failed to download notification image: HTTP 404 Not found")
+```
+
+`Androlog.log(category, text)` is the explicit equivalent. Each entry records:
+
+| Field | Source |
+|---|---|
+| `timestamp` | `System.currentTimeMillis()` at log time |
+| `category` | caller-provided free text (e.g. `"Notifications"`) |
+| `text` | the log message |
+
+Other members:
+
+- `Androlog.getEntries(): List<Entry>` — snapshot for the UI.
+- `Androlog.clear()` — wipe in-memory + persisted log.
+- `Androlog.init(context)` — called once in `AndromuksApplication.onCreate()`. Loads persisted entries and flushes anything logged before a context was available.
+
+Each call also mirrors to logcat via `Log.i("Androlog", "[$category] $text")`. `Log.i` survives R8, so the same line is visible in a live logcat dump too.
+
+## Storage & limits
+
+- In-memory list capped at `MAX_ENTRIES = 200` (oldest dropped first).
+- Persisted to `SharedPreferences("AndromuksAndrologPrefs")` under key `androlog`, as a JSON array of `{timestamp, category, text}`. Written with `apply()` (best-effort, non-blocking) — mirrors the WebSocket activity-log pattern in [`DiagnosticsCoordinator`](../app/src/main/java/net/vrkknn/andromuks/DiagnosticsCoordinator.kt).
+- Calls made before `init()` are buffered in memory and persisted on the next `init()`; persisted entries load ahead of those pre-init entries.
+- Thread-safe: all list mutation is `synchronized` on a private lock.
+
+## UI
+
+`AndrologScreen` (`app/src/main/java/net/vrkknn/andromuks/AndrologScreen.kt`), reached from **Settings → WebSocket Debug → "Androlog" → View Androlog** (nav route `"androlog"`, registered in `MainActivity`). It mirrors `ReconnectionLogScreen`:
+
+- Entries listed newest-first; each card shows the timestamp, a category chip, and the text.
+- **Export** writes a `timestamp | category | text` `.txt` via the system document picker.
+- **Clear** (trash icon) wipes the log.
+
+## Current instrumentation
+
+All under the `"Notifications"` category, so the export groups them together.
+
+| Location | What it logs |
+|---|---|
+| `EnhancedNotificationDisplay.showEnhancedNotification` (Phase 2 enqueue gate) | `hasImage` is true but no download URL could be resolved (`deferredHttpUrl == null`), so `NotificationImageWorker` is never enqueued and the notification stays text-only forever. |
+| `NotificationImageWorker.doWork` — notification gone | The notification was dismissed / marked read before the worker ran, so the image update is skipped (`Result.success`). |
+| `NotificationImageWorker.doWork` — download threw | Download raised an exception; notes the attempt number and whether it will retry or has given up after 3 attempts. |
+| `NotificationImageWorker.doWork` — file missing | Download returned no usable file; notes retry-vs-give-up. |
+| `NotificationImageWorker.doWork` — FileProvider failed | Could not wrap the downloaded file in a `content://` URI. |
+| `NotificationImageWorker.doWork` — MessagingStyle missing/empty | Could not extract `MessagingStyle` from the active notification, or it had no messages to upgrade. |
+| `NotificationImageWorker.doWork` — success | The notification was updated with the image. Lets you distinguish "worker never ran" from "worker ran and succeeded" when reading the log. |
+
+The two-phase image flow these probes cover is documented in [docs/NOTIFICATIONS.md](NOTIFICATIONS.md).
+
+When adding new probes, keep the category short and stable (it renders as a chip and groups related events when scanning the export).


### PR DESCRIPTION
Add Androlog, a process-wide singleton for cherry-picked events that survive R8 stripping (unlike Log.d). Entries record timestamp, category, and text; kept in memory (cap 200) and persisted to SharedPreferences, viewable and exportable via a new Settings screen in both debug and release builds.

Instrument the two-phase notification image flow as the first use:
- EnhancedNotificationDisplay: log when an image URL can't be resolved so the Phase 2 worker is never enqueued.
- NotificationImageWorker: log each silent/early-return path (dismissed, download threw, file missing, FileProvider failed, MessagingStyle missing/empty) plus the success path, to debug why image notifications fail to update after the worker runs.