### PR TITLE
Add message search (search_local/search_server) with header overflow menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,3 +161,4 @@ When investigating protocol behaviour, message shapes, or backend fields, consul
 | Reactions lifecycle, storage, redaction path, `removeReaction` internals | [docs/REACTIONS.md](docs/REACTIONS.md) |
 | Element Call (WebView/WebRTC, call state, incoming banners, timeline narrator, widget protocol) | [docs/ELEMENT_CALL.md](docs/ELEMENT_CALL.md) |
 | Androlog (persistent release-safe event log, `Androlog(category, text)`, viewer screen) | [docs/ANDROLOG.md](docs/ANDROLOG.md) |
+| Message search (`search_local`/`search_server`, SearchResultsScreen, next_batch pagination) | [docs/SEARCH.md](docs/SEARCH.md) |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 
 
         // Update versionName for each release (e.g., 1.0, 1.1, 1.2, 2.0)
-        versionName = "1.0.94"
+        versionName = "1.0.95"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/net/vrkknn/andromuks/AppViewModel.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/AppViewModel.kt
@@ -4875,6 +4875,8 @@ class AppViewModel : ViewModel() {
     internal val galleryPaginateRequests = mutableMapOf<Int, (List<TimelineEvent>, Boolean, Long) -> Unit>()
     // Thread paginate (paginate_manual with thread_root): requestId -> callback(events, nextBatch)
     internal val threadPaginateRequests = mutableMapOf<Int, (List<TimelineEvent>, String) -> Unit>()
+    // Message search (search_local / search_server): requestId -> callback(events, nextBatch)
+    internal val searchRequests = mutableMapOf<Int, (List<TimelineEvent>, String) -> Unit>()
     internal val userEncryptionInfoRequests = mutableMapOf<Int, (net.vrkknn.andromuks.utils.UserEncryptionInfo?, String?) -> Unit>() // requestId -> callback
     private val mutualRoomsRequests = mutableMapOf<Int, (List<String>?, String?) -> Unit>() // requestId -> callback
     internal val basicProfileCallbacks = mutableMapOf<Int, (MemberProfile?) -> Unit>() // requestId -> callback for direct get_profile consumers
@@ -6976,6 +6978,7 @@ class AppViewModel : ViewModel() {
                     widgetCommandRequests.containsKey(requestId) ||
                     galleryPaginateRequests.containsKey(requestId) ||
                     threadPaginateRequests.containsKey(requestId) ||
+                    searchRequests.containsKey(requestId) ||
                     createRoomRequests.containsKey(requestId)
 
             // If it's NOT in any request map, it's truly stale - ignore it
@@ -7057,6 +7060,8 @@ class AppViewModel : ViewModel() {
             handleGalleryPaginateResponse(requestId, data)
         } else if (threadPaginateRequests.containsKey(requestId)) {
             handleThreadPaginateResponse(requestId, data)
+        } else if (searchRequests.containsKey(requestId)) {
+            handleSearchResponse(requestId, data)
         } else if (createRoomRequests.containsKey(requestId)) {
             handleCreateRoomResponse(requestId, data)
         } else {
@@ -8543,6 +8548,115 @@ class AppViewModel : ViewModel() {
             callback(events, nextBatch)
         } catch (e: Exception) {
             android.util.Log.e("Andromuks", "AppViewModel: paginateThread - error handling response", e)
+            callback(emptyList(), "")
+        }
+    }
+
+    /**
+     * Search for messages via either `search_local` (SQLite FTS5 over the local database) or
+     * `search_server` (homeserver search). Both return a ManualPaginationResponse — the same
+     * `{events, next_batch}` shape that [paginateThread] consumes — so the response handling is
+     * identical apart from the request map.
+     *
+     * @param searchTerm Free-text query. For local search this is an FTS5 MATCH expression.
+     * @param searchLocal true → `search_local`; false → `search_server`.
+     * @param roomIds Restrict to these rooms. Empty = all rooms.
+     * @param senders Restrict to these senders. Empty = all senders.
+     * @param sortByTime Sort by timestamp instead of relevance.
+     * @param includeRedacted (local only) also search redacted events.
+     * @param limit Max results per page.
+     * @param nextBatch Continuation token from a previous response; all other params must match.
+     * @param callback (events, nextBatch) — parsed TimelineEvents + continuation token.
+     */
+    fun searchMessages(
+        searchTerm: String,
+        searchLocal: Boolean,
+        roomIds: List<String> = emptyList(),
+        senders: List<String> = emptyList(),
+        sortByTime: Boolean = false,
+        includeRedacted: Boolean = false,
+        limit: Int = 50,
+        nextBatch: String = "",
+        callback: (events: List<TimelineEvent>, nextBatch: String) -> Unit
+    ) {
+        if (!isWebSocketConnected()) {
+            android.util.Log.w("Andromuks", "AppViewModel: searchMessages - WebSocket not connected, calling back empty")
+            callback(emptyList(), "")
+            return
+        }
+        val requestId = WebSocketService.allocateRequestId()
+        searchRequests[requestId] = callback
+        val command = if (searchLocal) "search_local" else "search_server"
+        val data = mutableMapOf<String, Any>(
+            "search_term" to searchTerm,
+            "raw_like" to "",
+            "limit" to limit,
+            "room_ids" to roomIds,
+            "senders" to senders,
+            "sort_by_time" to sortByTime
+        )
+        // include_redacted is a search_local-only parameter.
+        if (searchLocal) {
+            data["include_redacted"] = includeRedacted
+        }
+        if (nextBatch.isNotBlank()) {
+            data["next_batch"] = nextBatch
+        }
+        if (BuildConfig.DEBUG) android.util.Log.d("Andromuks", "AppViewModel: searchMessages - command=$command, term='$searchTerm', rooms=$roomIds, sortByTime=$sortByTime, includeRedacted=$includeRedacted, requestId=$requestId")
+        val result = sendWebSocketCommand(command, requestId, data)
+        if (result != WebSocketResult.SUCCESS) {
+            android.util.Log.w("Andromuks", "AppViewModel: searchMessages - failed to send $command (result=$result)")
+            searchRequests.remove(requestId)
+            callback(emptyList(), "")
+            return
+        }
+        // Timeout so the screen never waits forever
+        viewModelScope.launch(Dispatchers.IO) {
+            delay(15000L)
+            if (searchRequests.containsKey(requestId)) {
+                android.util.Log.w("Andromuks", "AppViewModel: searchMessages timeout for requestId=$requestId")
+                withContext(Dispatchers.Main) {
+                    searchRequests.remove(requestId)?.invoke(emptyList(), "")
+                }
+            }
+        }
+    }
+
+    private fun handleSearchResponse(requestId: Int, data: Any) {
+        val callback = searchRequests.remove(requestId) ?: return
+        try {
+            val events = mutableListOf<TimelineEvent>()
+            var nextBatch = ""
+            when (data) {
+                is JSONObject -> {
+                    nextBatch = data.optString("next_batch", "")
+                    val eventsArray = data.optJSONArray("events")
+                    if (eventsArray != null) {
+                        for (i in 0 until eventsArray.length()) {
+                            val json = eventsArray.optJSONObject(i) ?: continue
+                            try {
+                                events.add(TimelineEvent.fromJson(json))
+                            } catch (e: Exception) {
+                                android.util.Log.e("Andromuks", "AppViewModel: searchMessages - error parsing event at index $i: ${e.message}", e)
+                            }
+                        }
+                    }
+                }
+                is JSONArray -> {
+                    for (i in 0 until data.length()) {
+                        val json = data.optJSONObject(i) ?: continue
+                        try {
+                            events.add(TimelineEvent.fromJson(json))
+                        } catch (e: Exception) {
+                            android.util.Log.e("Andromuks", "AppViewModel: searchMessages - error parsing event at index $i: ${e.message}", e)
+                        }
+                    }
+                }
+            }
+            if (BuildConfig.DEBUG) android.util.Log.d("Andromuks", "AppViewModel: searchMessages - parsed ${events.size} events, next_batch='$nextBatch'")
+            callback(events, nextBatch)
+        } catch (e: Exception) {
+            android.util.Log.e("Andromuks", "AppViewModel: searchMessages - error handling response", e)
             callback(emptyList(), "")
         }
     }

--- a/app/src/main/java/net/vrkknn/andromuks/MainActivity.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/MainActivity.kt
@@ -1774,6 +1774,21 @@ fun AppNavigation(
             )
         }
         composable(
+            route = "search?roomId={roomId}",
+            arguments = listOf(navArgument("roomId") {
+                type = NavType.StringType
+                nullable = true
+                defaultValue = null
+            })
+        ) { backStackEntry ->
+            SearchResultsScreen(
+                appViewModel = appViewModel,
+                navController = navController,
+                modifier = modifier,
+                roomId = backStackEntry.arguments?.getString("roomId")
+            )
+        }
+        composable(
             route = "cached_profiles/{cacheType}",
             arguments = listOf(navArgument("cacheType") { type = NavType.StringType })
         ) { backStackEntry: NavBackStackEntry ->

--- a/app/src/main/java/net/vrkknn/andromuks/RoomTimelineScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/RoomTimelineScreen.kt
@@ -99,6 +99,7 @@ import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.VideoCall
 import androidx.compose.material.icons.filled.Close
@@ -3375,6 +3376,10 @@ fun RoomTimelineScreen(
                             isRefreshing = true
                             appViewModel.setAutoPaginationEnabled(false, "manual_refresh_ui_$roomId")
                             appViewModel.fullRefreshRoomTimeline(roomId)
+                        },
+                        onSearchClick = {
+                            val encodedRoomId = java.net.URLEncoder.encode(roomId, "UTF-8")
+                            navController.navigate("search?roomId=$encodedRoomId")
                         }
                     )
 
@@ -6063,7 +6068,8 @@ fun RoomHeader(
     onCallClick: () -> Unit = {},
     callInProgress: Boolean = false,
     callActiveInRoom: Boolean = false,
-    onRefreshClick: () -> Unit = {}
+    onRefreshClick: () -> Unit = {},
+    onSearchClick: () -> Unit = {}
 ) {
     // Debug logging
     if (BuildConfig.DEBUG) android.util.Log.d("Andromuks", "RoomHeader: roomState = $roomState")
@@ -6294,6 +6300,16 @@ fun RoomHeader(
                         },
                         leadingIcon = {
                             Icon(Icons.Filled.Notifications, contentDescription = null)
+                        }
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Search") },
+                        onClick = {
+                            moreExpanded = false
+                            onSearchClick()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Filled.Search, contentDescription = null)
                         }
                     )
                 }

--- a/app/src/main/java/net/vrkknn/andromuks/RoomTimelineScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/RoomTimelineScreen.kt
@@ -98,6 +98,7 @@ import androidx.compose.material.icons.filled.Mood
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material.icons.filled.CloudOff
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.VideoCall
 import androidx.compose.material.icons.filled.Close
@@ -108,6 +109,8 @@ import androidx.compose.material.icons.filled.Cameraswitch
 import androidx.compose.material.icons.outlined.StickyNote2
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.OutlinedButton
 import net.vrkknn.andromuks.ui.components.ExpressiveLoadingIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -6208,13 +6211,6 @@ fun RoomHeader(
                     modifier = Modifier.size(20.dp)
                 )
             }
-            IconButton(onClick = onNotificationsClick) {
-                Icon(
-                    imageVector = Icons.Filled.Notifications,
-                    contentDescription = "Room notifications",
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
             val callIsLive = callInProgress || callActiveInRoom
             val callPulse = rememberInfiniteTransition(label = "call_pulse")
             val callPulseAlpha by callPulse.animateFloat(
@@ -6272,6 +6268,33 @@ fun RoomHeader(
                         imageVector = androidx.compose.material.icons.Icons.Filled.Refresh,
                         contentDescription = "Refresh timeline",
                         tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            // "More" overflow menu (3-dot). Hosts secondary actions to keep the header compact.
+            var moreExpanded by remember { mutableStateOf(false) }
+            Box {
+                IconButton(onClick = { moreExpanded = true }) {
+                    Icon(
+                        imageVector = Icons.Filled.MoreVert,
+                        contentDescription = "More",
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                DropdownMenu(
+                    expanded = moreExpanded,
+                    onDismissRequest = { moreExpanded = false }
+                ) {
+                    DropdownMenuItem(
+                        text = { Text("Mentions") },
+                        onClick = {
+                            moreExpanded = false
+                            onNotificationsClick()
+                        },
+                        leadingIcon = {
+                            Icon(Icons.Filled.Notifications, contentDescription = null)
+                        }
                     )
                 }
             }

--- a/app/src/main/java/net/vrkknn/andromuks/SearchResultsScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/SearchResultsScreen.kt
@@ -244,7 +244,7 @@ fun SearchResultsScreen(
                                 onCheckedChange = { sortByTime = it }
                             )
                             SearchOptionRow(
-                                label = "Search local database",
+                                label = "Search backend database",
                                 checked = searchLocal,
                                 onCheckedChange = { searchLocal = it }
                             )

--- a/app/src/main/java/net/vrkknn/andromuks/SearchResultsScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/SearchResultsScreen.kt
@@ -1,0 +1,534 @@
+package net.vrkknn.andromuks
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.surfaceColorAtElevation
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import kotlinx.coroutines.flow.distinctUntilChanged
+import net.vrkknn.andromuks.ui.components.AvatarImage
+import net.vrkknn.andromuks.ui.components.ExpressiveLoadingIndicator
+import net.vrkknn.andromuks.ui.theme.AndromuksTheme
+
+/** Sealed class for search result items (events and date dividers). */
+sealed class SearchResultItem {
+    abstract val stableKey: String
+
+    data class Event(val event: TimelineEvent) : SearchResultItem() {
+        override val stableKey: String get() = event.eventId
+    }
+
+    // anchorEventId disambiguates dividers: search results may be relevance-sorted, so the same
+    // calendar date can appear in multiple non-contiguous segments. Keying on the date alone would
+    // produce duplicate LazyColumn keys and crash. The anchor is the first event under the divider.
+    data class DateDivider(val date: String, val anchorEventId: String) : SearchResultItem() {
+        override val stableKey: String get() = "date_${date}_$anchorEventId"
+    }
+}
+
+/**
+ * Message search screen. Lets the user search messages either on the homeserver
+ * (`search_server`) or in the local database (`search_local`), with a few options.
+ *
+ * - **Current room only** (default on): restrict the search to [roomId].
+ * - **Sort by time** (default off): order results by timestamp instead of relevance.
+ * - **Search local database** (default off, on for E2EE rooms): use `search_local` instead of
+ *   `search_server`. E2EE rooms default to local because the homeserver can't search their
+ *   encrypted contents.
+ * - **Include redacted events** (default off, hidden unless local search is on): only meaningful
+ *   for `search_local`.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchResultsScreen(
+    navController: NavController,
+    modifier: Modifier = Modifier,
+    appViewModel: AppViewModel = viewModel(),
+    roomId: String? = null
+) {
+    val homeserverUrl = appViewModel.homeserverUrl
+    val authToken = appViewModel.authToken
+    val myUserId = appViewModel.currentUserId
+
+    val isRoomEncrypted = remember(roomId) {
+        when {
+            roomId == null -> false
+            appViewModel.currentRoomId == roomId && appViewModel.currentRoomState != null ->
+                appViewModel.currentRoomState?.isEncrypted ?: false
+            else -> isRoomEncryptedFromState(appViewModel.getRoomState(roomId)) ?: false
+        }
+    }
+
+    var searchTerm by remember { mutableStateOf("") }
+    var currentRoomOnly by remember { mutableStateOf(roomId != null) }
+    var sortByTime by remember { mutableStateOf(false) }
+    // E2EE rooms can't be searched on the server, so default to local search there.
+    var searchLocal by remember { mutableStateOf(isRoomEncrypted) }
+    var includeRedacted by remember { mutableStateOf(false) }
+
+    var isSearching by remember { mutableStateOf(false) }
+    var hasSearched by remember { mutableStateOf(false) }
+    var results by remember { mutableStateOf<List<TimelineEvent>>(emptyList()) }
+    var nextBatch by remember { mutableStateOf("") }
+
+    fun runSearch(append: Boolean) {
+        val term = searchTerm.trim()
+        if (term.isEmpty()) return
+        isSearching = true
+        hasSearched = true
+        val roomIds = if (currentRoomOnly && roomId != null) listOf(roomId) else emptyList()
+        appViewModel.searchMessages(
+            searchTerm = term,
+            searchLocal = searchLocal,
+            roomIds = roomIds,
+            sortByTime = sortByTime,
+            includeRedacted = searchLocal && includeRedacted,
+            limit = 50,
+            nextBatch = if (append) nextBatch else ""
+        ) { events, batch ->
+            results = if (append) results + events else events
+            nextBatch = batch
+            isSearching = false
+        }
+    }
+
+    // Build list items with date dividers (results are ordered as the server returns them).
+    val resultItems = remember(results) {
+        val items = mutableListOf<SearchResultItem>()
+        var lastDate: String? = null
+        val seenEventIds = HashSet<String>()
+        for (event in results) {
+            // Paginated pages can overlap; skip events already shown so LazyColumn keys stay unique.
+            if (!seenEventIds.add(event.eventId)) continue
+            val date = formatDate(event.timestamp)
+            if (lastDate == null || date != lastDate) {
+                items.add(SearchResultItem.DateDivider(date, event.eventId))
+                lastDate = date
+            }
+            items.add(SearchResultItem.Event(event))
+        }
+        items
+    }
+
+    val listState = rememberLazyListState()
+    val statusBarTop = androidx.compose.foundation.layout.WindowInsets.statusBars
+        .asPaddingValues().calculateTopPadding()
+
+    // Hoisted out of the LazyColumn content lambda so the footer's presence reacts reliably.
+    val hasMore = nextBatch.isNotBlank()
+
+    // Infinite scroll: auto-fetch the next page when the user scrolls near the end.
+    LaunchedEffect(listState, hasMore, resultItems.size) {
+        if (!hasMore) return@LaunchedEffect
+        androidx.compose.runtime.snapshotFlow {
+            val layoutInfo = listState.layoutInfo
+            val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            lastVisible to layoutInfo.totalItemsCount
+        }
+            .distinctUntilChanged()
+            .collect { (lastVisible, total) ->
+                if (total > 0 && lastVisible >= total - 3 && !isSearching && nextBatch.isNotBlank()) {
+                    runSearch(append = true)
+                }
+            }
+    }
+
+    AndromuksTheme {
+        Surface {
+            Box(modifier = modifier.fillMaxSize()) {
+                Column(modifier = Modifier.fillMaxSize()) {
+                    // Header
+                    Surface(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = statusBarTop),
+                        color = MaterialTheme.colorScheme.surfaceColorAtElevation(3.dp)
+                    ) {
+                        Column(modifier = Modifier.fillMaxWidth()) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 4.dp, vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                IconButton(onClick = { navController.popBackStack() }) {
+                                    Icon(
+                                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                        contentDescription = "Back"
+                                    )
+                                }
+                                Text(
+                                    text = "Search",
+                                    style = MaterialTheme.typography.titleLarge,
+                                    fontWeight = FontWeight.Bold,
+                                    modifier = Modifier.weight(1f)
+                                )
+                            }
+
+                            // Search text box
+                            OutlinedTextField(
+                                value = searchTerm,
+                                onValueChange = { searchTerm = it },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 12.dp, vertical = 4.dp),
+                                placeholder = { Text("Search messages") },
+                                singleLine = true,
+                                trailingIcon = {
+                                    IconButton(onClick = { runSearch(append = false) }) {
+                                        Icon(
+                                            imageVector = Icons.Filled.Search,
+                                            contentDescription = "Search"
+                                        )
+                                    }
+                                },
+                                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                                keyboardActions = KeyboardActions(onSearch = { runSearch(append = false) })
+                            )
+
+                            // Options
+                            SearchOptionRow(
+                                label = "Current room only",
+                                checked = currentRoomOnly,
+                                enabled = roomId != null,
+                                onCheckedChange = { currentRoomOnly = it }
+                            )
+                            SearchOptionRow(
+                                label = "Sort by time",
+                                checked = sortByTime,
+                                onCheckedChange = { sortByTime = it }
+                            )
+                            SearchOptionRow(
+                                label = "Search local database",
+                                checked = searchLocal,
+                                onCheckedChange = { searchLocal = it }
+                            )
+                            if (searchLocal) {
+                                SearchOptionRow(
+                                    label = "Include redacted events",
+                                    checked = includeRedacted,
+                                    onCheckedChange = { includeRedacted = it }
+                                )
+                            }
+                            Spacer(modifier = Modifier.height(4.dp))
+                        }
+                    }
+
+                    // Results
+                    Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                        when {
+                            isSearching && results.isEmpty() -> {
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.Center
+                                    ) {
+                                        ExpressiveLoadingIndicator(modifier = Modifier.size(96.dp))
+                                        Spacer(modifier = Modifier.height(16.dp))
+                                        Text(
+                                            text = "Searching...",
+                                            style = MaterialTheme.typography.bodyLarge,
+                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                        )
+                                    }
+                                }
+                            }
+                            hasSearched && resultItems.isEmpty() -> {
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = "No results found",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                            !hasSearched -> {
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = "Enter a search term",
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                            else -> {
+                                LazyColumn(
+                                    state = listState,
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .navigationBarsPadding()
+                                        .imePadding(),
+                                    contentPadding = PaddingValues(
+                                        start = 8.dp,
+                                        end = 8.dp,
+                                        top = 8.dp,
+                                        bottom = 8.dp
+                                    )
+                                ) {
+                                    items(
+                                        items = resultItems,
+                                        key = { it.stableKey }
+                                    ) { item ->
+                                        when (item) {
+                                            is SearchResultItem.DateDivider -> DateDivider(item.date)
+                                            is SearchResultItem.Event -> SearchResultCard(
+                                                event = item.event,
+                                                homeserverUrl = homeserverUrl,
+                                                authToken = authToken,
+                                                myUserId = myUserId,
+                                                appViewModel = appViewModel,
+                                                navController = navController
+                                            )
+                                        }
+                                    }
+                                    // Footer: shown whenever more pages exist. Pages auto-load on
+                                    // scroll, but tapping forces the next page too.
+                                    if (hasMore) {
+                                        item(key = "load_more") {
+                                            Box(
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .clickable(enabled = !isSearching) { runSearch(append = true) }
+                                                    .padding(16.dp),
+                                                contentAlignment = Alignment.Center
+                                            ) {
+                                                if (isSearching) {
+                                                    ExpressiveLoadingIndicator(modifier = Modifier.size(32.dp))
+                                                } else {
+                                                    Text(
+                                                        text = "Load more",
+                                                        style = MaterialTheme.typography.labelLarge,
+                                                        color = MaterialTheme.colorScheme.primary
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SearchOptionRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    enabled: Boolean = true
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 2.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (enabled) MaterialTheme.colorScheme.onSurface
+            else MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
+            modifier = Modifier.weight(1f)
+        )
+        Switch(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            enabled = enabled
+        )
+    }
+}
+
+/** Renders a single search result with room context, sender, timestamp and content. */
+@Composable
+private fun SearchResultCard(
+    event: TimelineEvent,
+    homeserverUrl: String,
+    authToken: String,
+    myUserId: String?,
+    appViewModel: AppViewModel,
+    navController: NavController
+) {
+    val roomId = event.roomId
+    val room = appViewModel.getRoomById(roomId)
+    val roomName = room?.name ?: roomId
+
+    // Request the sender's profile on demand if missing.
+    LaunchedEffect(event.sender, roomId) {
+        val existing = appViewModel.getUserProfile(event.sender, roomId)
+        if (existing == null || existing.displayName.isNullOrBlank()) {
+            appViewModel.requestUserProfileOnDemand(event.sender, roomId)
+        }
+    }
+
+    val senderProfile = appViewModel.getUserProfile(event.sender, roomId)
+    val senderName = senderProfile?.displayName ?: event.sender.removePrefix("@").substringBefore(":")
+    val senderAvatarUrl = senderProfile?.avatarUrl
+
+    val content = event.decrypted ?: event.content
+    val format = content?.optString("format", "")
+    val body = if (format == "org.matrix.custom.html") {
+        content?.optString("formatted_body", "")?.takeIf { it.isNotBlank() }
+            ?: content?.optString("body", "") ?: ""
+    } else {
+        content?.optString("body", "") ?: ""
+    }
+
+    val userProfileCache = remember(roomId, appViewModel.memberUpdateCounter) {
+        appViewModel.getMemberMap(roomId)
+    }
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .clickable {
+                val encodedRoomId = java.net.URLEncoder.encode(roomId, "UTF-8")
+                val encodedEventId = java.net.URLEncoder.encode(event.eventId, "UTF-8")
+                navController.navigate("event_context/$encodedRoomId/$encodedEventId")
+            },
+        shape = RoundedCornerShape(12.dp),
+        color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
+        tonalElevation = 1.dp
+    ) {
+        Column(modifier = Modifier.fillMaxWidth().padding(12.dp)) {
+            // Room context
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                AvatarImage(
+                    mxcUrl = room?.avatarUrl,
+                    homeserverUrl = homeserverUrl,
+                    authToken = authToken,
+                    fallbackText = roomName.take(1),
+                    size = 24.dp,
+                    userId = roomId,
+                    displayName = roomName
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = roomName,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            // Sender and message
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.Top
+            ) {
+                AvatarImage(
+                    mxcUrl = senderAvatarUrl,
+                    homeserverUrl = homeserverUrl,
+                    authToken = authToken,
+                    fallbackText = senderName.take(1),
+                    size = 32.dp,
+                    userId = event.sender,
+                    displayName = senderName
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = senderName,
+                            style = MaterialTheme.typography.bodyMedium,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = formatTimeShort(event.timestamp),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            fontSize = 11.sp
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(4.dp))
+                    AdaptiveMessageText(
+                        event = event,
+                        body = body,
+                        format = format,
+                        userProfileCache = userProfileCache,
+                        homeserverUrl = homeserverUrl,
+                        authToken = authToken,
+                        appViewModel = appViewModel,
+                        roomId = roomId,
+                        textColor = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun formatTimeShort(timestamp: Long): String {
+    val formatter = java.text.SimpleDateFormat("HH:mm", java.util.Locale.getDefault())
+    return formatter.format(java.util.Date(timestamp))
+}

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -1,0 +1,99 @@
+# Message Search
+
+`SearchResultsScreen` lets the user search messages either on the homeserver
+(`search_server`) or in the local SQLite database (`search_local`), with a few
+toggles. It is reached from the **More (⋮)** overflow menu in the room timeline
+header (`RoomTimelineScreen` → `RoomHeader`).
+
+## Entry point & navigation
+
+- **Header menu**: `RoomHeader`'s overflow (`MoreVert`) dropdown contains a
+  **Search** item. It navigates to `search?roomId={roomId}` with the current
+  room ID URL-encoded.
+- **Route**: defined in `MainActivity` as `search?roomId={roomId}` (nullable
+  arg, mirrors the `mentions` route) → `SearchResultsScreen(roomId = ...)`.
+
+## UI
+
+A header with a back button + title, a search text box, and four option
+switches:
+
+| Option | Default | Notes |
+|---|---|---|
+| **Current room only** | on (off/disabled if no room context) | Restricts the search to `roomId`. |
+| **Sort by time** | off | Order by timestamp instead of relevance. |
+| **Search local database** | off (**on** if the room is E2EE) | Picks `search_local` vs `search_server`. The homeserver can't search encrypted content, so E2EE rooms default to local. |
+| **Include redacted events** | off | **Hidden unless local search is on** — it's a `search_local`-only parameter. |
+
+E2EE detection prefers `currentRoomState?.isEncrypted` when the search room is
+the active room, otherwise falls back to
+`isRoomEncryptedFromState(getRoomState(roomId))`.
+
+Results render as cards (modeled on `MentionsScreen`'s `MentionItem`): room
+context (avatar + name) + sender + time + message body via
+`AdaptiveMessageText`, grouped under date dividers. Tapping a result navigates
+to `event_context/{roomId}/{eventId}` (`EventContextScreen`), which loads the
+message in context (5 before / 5 after) and scrolls to it.
+
+## WebSocket protocol
+
+Both commands return a `ManualPaginationResponse` — `{ events, next_batch }`
+(the same shape `paginate_manual` uses) — so the app handles them through one
+path.
+
+`AppViewModel.searchMessages(...)` builds the request and issues either
+`search_local` or `search_server` depending on the `searchLocal` flag:
+
+```jsonc
+// search_local
+{"command":"search_local","request_id":N,"data":{
+  "search_term":"…","raw_like":"","limit":50,
+  "room_ids":["!room:hs"],"senders":[],
+  "include_redacted":false,"sort_by_time":false}}
+
+// search_server (no include_redacted)
+{"command":"search_server","request_id":N,"data":{
+  "search_term":"…","raw_like":"","limit":50,
+  "room_ids":["!room:hs"],"senders":[],"sort_by_time":false}}
+```
+
+- `include_redacted` is sent **only** for `search_local` (server search ignores
+  it).
+- `next_batch` is added to `data` only when continuing a previous search; per
+  the API contract, all other params must remain identical between pages.
+
+Wiring in `AppViewModel`:
+
+- `searchRequests: MutableMap<Int, (List<TimelineEvent>, String) -> Unit>` —
+  pending requests keyed by `request_id`, parallel to `threadPaginateRequests`.
+- `handleSearchResponse(...)` parses `events` into `TimelineEvent`s (via
+  `TimelineEvent.fromJson`, which reads `room_id`) and the `next_batch` token.
+- Registered in the `isInRequestMap` staleness guard and the response dispatch
+  chain.
+- A 15 s timeout invokes the callback with empty results so the screen never
+  hangs.
+
+## Pagination (`next_batch`)
+
+Both commands support pagination:
+
+- **`search_local`**: offset-based. The server emits
+  `next_batch = "local_offset:<N>"` **only when the page comes back full**
+  (`len(events) >= limit`). A short page means no more results, so no token.
+- **`search_server`**: returns the homeserver's own Matrix `/search`
+  `next_batch` cursor, independent of page fullness.
+
+The screen keeps the latest token and **auto-loads** the next page via a
+`snapshotFlow` on the last visible index (fetches when within 3 items of the
+end and a token exists). A footer also shows a spinner while loading and acts
+as a manual "Load more" tap. Overlapping pages are de-duplicated by `eventId`.
+
+## Date-divider keys (crash guard)
+
+Search results — especially relevance-sorted (`sort_by_time = false`) — repeat
+the same calendar date in non-contiguous segments. Keying `LazyColumn` date
+dividers on the date string alone produced duplicate keys and an
+`IllegalArgumentException`. The fix: `SearchResultItem.DateDivider` carries the
+**anchor event ID** of the first event under it, making the key
+`date_${date}_$anchorEventId` unique per segment. This is the same
+non-monotonic-ordering pitfall noted for the main timeline.

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -1,9 +1,11 @@
 # Message Search
 
-`SearchResultsScreen` lets the user search messages either on the homeserver
-(`search_server`) or in the local SQLite database (`search_local`), with a few
-toggles. It is reached from the **More (⋮)** overflow menu in the room timeline
-header (`RoomTimelineScreen` → `RoomHeader`).
+`SearchResultsScreen` lets the user search messages either via the homeserver's
+search API (`search_server`) or against the gomuks backend's own SQLite database
+(`search_local`), with a few toggles. "Local" here means local to the gomuks
+**backend** (the server you connect to over the WebSocket) — the Android app has
+no message database of its own. It is reached from the **More (⋮)** overflow menu
+in the room timeline header (`RoomTimelineScreen` → `RoomHeader`).
 
 ## Entry point & navigation
 
@@ -22,8 +24,8 @@ switches:
 |---|---|---|
 | **Current room only** | on (off/disabled if no room context) | Restricts the search to `roomId`. |
 | **Sort by time** | off | Order by timestamp instead of relevance. |
-| **Search local database** | off (**on** if the room is E2EE) | Picks `search_local` vs `search_server`. The homeserver can't search encrypted content, so E2EE rooms default to local. |
-| **Include redacted events** | off | **Hidden unless local search is on** — it's a `search_local`-only parameter. |
+| **Search backend database** | off (**on** if the room is E2EE) | Picks `search_local` (gomuks backend's SQLite DB) vs `search_server` (homeserver search API). The homeserver can't search encrypted content, so E2EE rooms default to the backend DB. |
+| **Include redacted events** | off | **Hidden unless backend-DB search is on** — it's a `search_local`-only parameter. |
 
 E2EE detection prefers `currentRoomState?.isEncrypted` when the search room is
 the active room, otherwise falls back to


### PR DESCRIPTION
## Summary

Adds in-app message search, reachable from a new **More (⋮)** overflow menu in the room timeline header.

- **Header overflow menu**: replaces the standalone Mentions button in `RoomHeader` with a 3-dot `MoreVert` dropdown (after Refresh), hosting **Mentions** and the new **Search** items — keeps the header compact for future actions.
- **`SearchResultsScreen`**: search text box + four toggles:
  - **Current room only** (default on)
  - **Sort by time** (default off)
  - **Search backend database** (default off; **on** for E2EE rooms, since the homeserver can't search encrypted content) — picks `search_local` vs `search_server`
  - **Include redacted events** (default off, hidden unless backend-DB search is on; `search_local`-only)
- Results render as cards (room context + sender + time + body via `AdaptiveMessageText`) grouped by date dividers; tapping a result opens it in `EventContextScreen`.

## Protocol

Both commands return the same `ManualPaginationResponse` (`{ events, next_batch }`).

- `AppViewModel.searchMessages(...)` issues either `search_local` or `search_server`; `handleSearchResponse(...)` parses events + `next_batch`. Registered in the staleness guard and response dispatch chain, with a 15s timeout.
- **Pagination** supported for both: auto-loads the next page on scroll via `next_batch` (offset token `local_offset:<N>` for local, homeserver cursor for server), with a spinner footer that also works as a manual "Load more".

## Crash guard

Date-divider `LazyColumn` keys carry the anchor event ID (`date_${date}_$anchorEventId`) so relevance-sorted results that repeat a date in non-contiguous segments don't produce duplicate keys (the same non-monotonic-ordering pitfall as the main timeline). Events are also de-duplicated by `eventId` across paginated pages.

## Other

- Bumped `versionName` to `1.0.95`.
- Documented in `docs/SEARCH.md` (+ row in the CLAUDE.md feature table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)