### PR TITLE
Encrypt credentials at rest, silent re-auth on token expiry, biometric lock

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ When investigating protocol behaviour, message shapes, or backend fields, consul
 | User profile architecture (two caches, resolution order, "do we have it?" sentinel, rendering fallback, UserInfoScreen bypass) | [docs/USER_PROFILES.md](docs/USER_PROFILES.md) |
 | Read receipts invariants and update paths | [docs/RECEIPTS.md](docs/RECEIPTS.md) |
 | Push notifications (FCM, two-phase images, image auth token) | [docs/NOTIFICATIONS.md](docs/NOTIFICATIONS.md) |
+| Secure credentials at rest, silent re-auth on token expiry, biometric lock | [docs/CREDENTIALS_REAUTH.md](docs/CREDENTIALS_REAUTH.md) |
 | Bridge support (detection, tab, badges, per-message profiles) | [docs/bridges.md](docs/bridges.md) |
 | Room display name & avatar resolution (m.heroes) | [docs/ROOM_DISPLAY.md](docs/ROOM_DISPLAY.md) |
 | RoomListScreen composable reference | [docs/ROOMLISTSCREEN.md](docs/ROOMLISTSCREEN.md) |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -101,6 +101,7 @@ if (project.hasProperty("compose.metrics")) {
 dependencies {
     implementation("androidx.profileinstaller:profileinstaller:1.3.1")
     implementation("androidx.core:core-ktx:1.17.0")
+    implementation("androidx.biometric:biometric:1.1.0")
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/net/vrkknn/andromuks/AndromuksApplication.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/AndromuksApplication.kt
@@ -54,6 +54,14 @@ class AndromuksApplication : Application() {
         migrateLegacyImageCache()
         // Initialise the Androlog store so cherry-picked events can be persisted/reviewed.
         Androlog.init(this)
+        // Off-main: migrate any legacy plaintext token to encrypted-at-rest, then warm the decrypted
+        // token into CredentialStore's in-memory cache so the first main-thread read (composition,
+        // sync processing) is a cache hit instead of a ~20 ms Keystore decrypt that trips StrictMode.
+        applicationScope.launch {
+            val prefs = getSharedPreferences("AndromuksAppPrefs", MODE_PRIVATE)
+            net.vrkknn.andromuks.utils.CredentialStore.migratePlaintextTokenIfNeeded(prefs)
+            net.vrkknn.andromuks.utils.CredentialStore.warmTokenCache(prefs)
+        }
     }
 
     private fun prewarmSharedPreferences() {

--- a/app/src/main/java/net/vrkknn/andromuks/AppViewModel.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/AppViewModel.kt
@@ -503,6 +503,10 @@ class AppViewModel : ViewModel() {
     // Room timeline read receipts layout: false = inline next to bubble, true = moved to opposite screen edge
     var moveReadReceiptsToEdge by mutableStateOf(false)
         internal set
+    // Require biometric/device-credential authentication when the app is foregrounded, and before
+    // re-authenticating with stored credentials on token expiry. See BiometricLockGate.
+    var requireBiometricUnlock by mutableStateOf(false)
+        internal set
     // Trim long display names in timeline: if true, names longer than 40 chars are trimmed with "..."
     var trimLongDisplayNames by mutableStateOf(true)
         internal set
@@ -3826,7 +3830,59 @@ class AppViewModel : ViewModel() {
     fun setUnauthorizedNavigationCallback(callback: (homeserverUrl: String, username: String) -> Unit) {
         onUnauthorized = callback
     }
-    
+
+    // Biometric re-auth handshake. When a 401 arrives and the user enabled "Require biometric",
+    // ReauthCoordinator asks the UI (via this callback) to run a BiometricPrompt whose subtitle
+    // explains it is for re-authentication. On success the UI calls
+    // ReauthCoordinator.completeBiometricReauth(...), which then re-logs in with stored credentials.
+    private var onBiometricReauthRequested: (() -> Unit)? = null
+    // Set true while a biometric-gated re-auth is pending UI action; lets a foregrounding Activity
+    // pick it up even if the callback wasn't registered at the moment the 401 fired.
+    var pendingBiometricReauth: Boolean = false
+        private set
+
+    fun setBiometricReauthCallback(callback: (() -> Unit)?) {
+        onBiometricReauthRequested = callback
+        // If a re-auth became pending before the UI registered, fire it now.
+        if (callback != null && pendingBiometricReauth) {
+            android.os.Handler(android.os.Looper.getMainLooper()).post { callback() }
+        }
+    }
+
+    /** Called by ReauthCoordinator to ask the UI to run the re-authentication biometric prompt. */
+    fun requestBiometricReauth() {
+        pendingBiometricReauth = true
+        val cb = onBiometricReauthRequested
+        if (cb != null) {
+            android.os.Handler(android.os.Looper.getMainLooper()).post { cb() }
+        }
+    }
+
+    /** Cleared by the UI once the biometric re-auth flow resolves (success or final cancel). */
+    fun clearPendingBiometricReauth() {
+        pendingBiometricReauth = false
+    }
+
+    /**
+     * Re-establishes the WebSocket after a successful re-auth produced a fresh session token. The
+     * old session's run_id is dropped so the backend starts a clean cold-start sync.
+     */
+    internal fun reconnectAfterReauth(homeserverUrl: String, token: String) {
+        android.os.Handler(android.os.Looper.getMainLooper()).post {
+            try {
+                appContext?.getSharedPreferences("AndromuksAppPrefs", android.content.Context.MODE_PRIVATE)
+                    ?.edit()?.remove("ws_run_id")?.apply()
+                currentRunId = ""
+                WebSocketService.clearReconnectionState()
+                updateAuthToken(token)
+                updateHomeserverUrl(homeserverUrl)
+                initializeWebSocketConnection(homeserverUrl, token, isReconnection = false)
+            } catch (e: Exception) {
+                android.util.Log.e("Andromuks", "AppViewModel: reconnectAfterReauth failed", e)
+            }
+        }
+    }
+
     // Pending room navigation from shortcuts
     internal var pendingRoomNavigation: String? = null
     
@@ -4149,7 +4205,7 @@ class AppViewModel : ViewModel() {
         val ctx = appContext ?: return
         val prefs = ctx.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
         val homeserverUrl = prefs.getString("homeserver_url", "") ?: ""
-        val authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+        val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
         if (homeserverUrl.isBlank() || authToken.isBlank()) {
             android.util.Log.w(
                 "Andromuks",
@@ -5552,14 +5608,34 @@ class AppViewModel : ViewModel() {
      * This should be called when WebSocket connection fails with 401 (invalid/expired token).
      */
     fun handleUnauthorizedError() {
-        android.util.Log.e("Andromuks", "AppViewModel: Handling 401 Unauthorized error - clearing credentials and navigating to login")
+        android.util.Log.e("Andromuks", "AppViewModel: Handling 401 Unauthorized error")
+        logActivity("401 Unauthorized", null)
+
+        // Try to silently re-authenticate with stored credentials before dropping the user back to
+        // the login screen. ReauthCoordinator returns true when it started (or is awaiting biometric
+        // confirmation for) a re-auth, in which case we must NOT clear the session here.
+        if (ReauthCoordinator.attempt(this)) {
+            android.util.Log.i("Andromuks", "AppViewModel: 401 - re-auth attempt started; deferring credential clear")
+            return
+        }
+
+        clearCredentialsAndNavigateToLogin()
+    }
+
+    /**
+     * Hard-clears the session (encrypted token + stored credentials + run_id) and navigates to the
+     * login screen with pre-filled homeserver URL and username. Used when no stored credentials
+     * exist or a re-auth attempt has definitively failed (genuinely changed/revoked password).
+     */
+    internal fun clearCredentialsAndNavigateToLogin() {
+        android.util.Log.e("Andromuks", "AppViewModel: Clearing credentials and navigating to login")
         logActivity("401 Unauthorized - Clearing Credentials", null)
-        
+
         val context = appContext ?: run {
             android.util.Log.e("Andromuks", "AppViewModel: Cannot handle 401 error - appContext is null")
             return
         }
-        
+
         try {
             val prefs = context.getSharedPreferences("AndromuksAppPrefs", android.content.Context.MODE_PRIVATE)
 
@@ -5573,8 +5649,8 @@ class AppViewModel : ViewModel() {
 
             val editor = prefs.edit()
 
-            // Clear auth token (this will cause AuthCheck to navigate to login)
-            editor.remove("gomuks_auth_token")
+            // Clear auth token (encrypted + any legacy plaintext) so AuthCheck routes to login.
+            net.vrkknn.andromuks.utils.CredentialStore.clearAuthToken(editor)
             editor.remove("homeserver_url")
 
             // Clear run_id
@@ -5589,7 +5665,11 @@ class AppViewModel : ViewModel() {
                 // Fallback to apply() if commit() fails (shouldn't happen, but be defensive)
                 editor.apply()
             }
-            
+
+            // Drop the stored login credentials and their Keystore key — reaching this path means
+            // the password is no longer valid (changed/revoked), so they must be re-entered.
+            net.vrkknn.andromuks.utils.CredentialStore.clearCredentials(prefs)
+
             // Clear in-memory state
             currentRunId = ""
             vapidKey = ""
@@ -10872,6 +10952,8 @@ class AppViewModel : ViewModel() {
     fun toggleMoveReadReceiptsToEdge() = settingsCoordinator.toggleMoveReadReceiptsToEdge()
 
     fun toggleTrimLongDisplayNames() = settingsCoordinator.toggleTrimLongDisplayNames()
+
+    fun setRequireBiometricUnlock(enabled: Boolean) = settingsCoordinator.setRequireBiometricUnlock(enabled)
 
     fun toggleShowLinkPreviews() = settingsCoordinator.toggleShowLinkPreviews()
 

--- a/app/src/main/java/net/vrkknn/andromuks/AuthCheck.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/AuthCheck.kt
@@ -38,7 +38,7 @@ fun AuthCheckScreen(
 
     LaunchedEffect(Unit) {
         appViewModel.isLoading = true
-        val token = sharedPreferences.getString("gomuks_auth_token", null)
+        val token = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPreferences).ifBlank { null }
         val homeserverUrl = sharedPreferences.getString("homeserver_url", null)
 
         if (token != null && homeserverUrl != null) {
@@ -378,7 +378,7 @@ fun AuthCheckScreen(
     // Only apply this if we have token and homeserver (i.e., not on login screen)
     val hasCredentials = remember {
         val prefs = context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
-        val token = prefs.getString("gomuks_auth_token", null)
+        val token = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs).ifBlank { null }
         val homeserverUrl = prefs.getString("homeserver_url", null)
         token != null && homeserverUrl != null
     }

--- a/app/src/main/java/net/vrkknn/andromuks/AutoRestartWorker.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/AutoRestartWorker.kt
@@ -42,7 +42,7 @@ class AutoRestartWorker(
             // Check if we have credentials (user is logged in)
             val prefs = applicationContext.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
             val homeserverUrl = prefs.getString("homeserver_url", "") ?: ""
-            val authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+            val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
 
             if (homeserverUrl.isEmpty() || authToken.isEmpty()) {
                 if (BuildConfig.DEBUG) Log.d(TAG, "No credentials found - user not logged in, skipping auto-restart check")

--- a/app/src/main/java/net/vrkknn/andromuks/BiometricLock.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/BiometricLock.kt
@@ -1,0 +1,253 @@
+package net.vrkknn.andromuks
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.os.Build
+import android.util.Log
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+
+/**
+ * Authenticators accepted by the app-lock / re-auth prompt. On API 30+ a strong biometric OR the
+ * device credential (PIN/pattern/password) is allowed in a single prompt. On API < 30 that
+ * combination is unsupported, so we allow strong biometric only and supply a negative button.
+ */
+private fun allowedAuthenticators(): Int =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        BiometricManager.Authenticators.BIOMETRIC_STRONG or BiometricManager.Authenticators.DEVICE_CREDENTIAL
+    } else {
+        BiometricManager.Authenticators.BIOMETRIC_STRONG
+    }
+
+/** True when the device can satisfy [allowedAuthenticators] (enrolled biometric or device credential). */
+fun canAuthenticate(context: Context): Boolean =
+    BiometricManager.from(context).canAuthenticate(allowedAuthenticators()) == BiometricManager.BIOMETRIC_SUCCESS
+
+private fun Context.findFragmentActivity(): FragmentActivity? {
+    var ctx: Context? = this
+    while (ctx is ContextWrapper) {
+        if (ctx is FragmentActivity) return ctx
+        ctx = ctx.baseContext
+    }
+    return null
+}
+
+private const val TAG = "BiometricLock"
+
+/**
+ * Runs a [BiometricPrompt]. [onSuccess] fires on authentication; [onFail] fires on a terminal error
+ * or user cancellation. Any exception from [BiometricPrompt.authenticate] (e.g. an unsupported
+ * authenticator combination) is caught and routed to [onFail] so callers never wedge.
+ */
+fun runBiometricPrompt(
+    activity: FragmentActivity,
+    title: String,
+    subtitle: String,
+    onSuccess: () -> Unit,
+    onFail: () -> Unit
+) {
+    val executor = ContextCompat.getMainExecutor(activity)
+    val prompt = BiometricPrompt(activity, executor, object : BiometricPrompt.AuthenticationCallback() {
+        override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) = onSuccess()
+        override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+            Log.w(TAG, "Biometric error $errorCode: $errString")
+            onFail()
+        }
+        // onAuthenticationFailed (a single non-matching attempt) is intentionally ignored — the
+        // prompt stays up and the user can retry.
+    })
+    val builder = BiometricPrompt.PromptInfo.Builder()
+        .setTitle(title)
+        .setSubtitle(subtitle)
+        .setAllowedAuthenticators(allowedAuthenticators())
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+        // Required when only BIOMETRIC_* authenticators are allowed.
+        builder.setNegativeButtonText("Cancel")
+    }
+    try {
+        prompt.authenticate(builder.build())
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to launch biometric prompt", e)
+        onFail()
+    }
+}
+
+/**
+ * Wraps app content with two behaviours, both active only when [AppViewModel.requireBiometricUnlock]
+ * is on and the device can authenticate:
+ *
+ *  1. **App lock** — a full-screen overlay shown on cold start, whenever the app returns to the
+ *     foreground (process `ON_STOP` → `ON_START`), and immediately when the user enables the
+ *     setting. The biometric/device-credential prompt is launched only while the activity is in the
+ *     foreground (`ON_RESUME`), never from the background.
+ *  2. **Re-auth gate** — registers [AppViewModel.setBiometricReauthCallback] so that when the session
+ *     token expires, the user authenticates (with a subtitle making clear it is for *re-authentication*)
+ *     before [ReauthCoordinator] re-logs in with the stored credentials.
+ *
+ * Excluded from chat-bubble windows by simply not wrapping [BubbleTimelineScreen].
+ */
+@Composable
+fun BiometricLockGate(
+    appViewModel: AppViewModel,
+    content: @Composable () -> Unit
+) {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findFragmentActivity() }
+    val prefs = remember(context) {
+        context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
+    }
+
+    // Read the setting synchronously from prefs rather than waiting on the async ViewModel load —
+    // otherwise a cold start composes this gate before requireBiometricUnlock is loaded (default
+    // false) and never locks. appViewModel.requireBiometricUnlock is observed only as a recomposition
+    // signal for runtime toggles; the persisted value (updated in-memory immediately by apply()) is
+    // the source of truth.
+    val requireSignal = appViewModel.requireBiometricUnlock
+    val require = remember(requireSignal) { prefs.getBoolean("require_biometric_unlock", false) }
+    val deviceCanAuth = remember(context, require) { canAuthenticate(context) }
+    val gateActive = require && deviceCanAuth && activity != null
+
+    // Locked until the user authenticates this foreground session. Survives rotation.
+    var unlocked by rememberSaveable { mutableStateOf(false) }
+    var promptInFlight by remember { mutableStateOf(false) }
+
+    val gateActiveState = rememberUpdatedState(gateActive)
+    val unlockedState = rememberUpdatedState(unlocked)
+
+    fun launchUnlockPrompt() {
+        if (activity == null || promptInFlight || !gateActiveState.value || unlockedState.value) return
+        promptInFlight = true
+        runBiometricPrompt(
+            activity,
+            title = "Unlock Andromuks",
+            subtitle = "Authenticate to access your messages",
+            onSuccess = { promptInFlight = false; unlocked = true },
+            onFail = { promptInFlight = false }
+        )
+    }
+
+    // Drive lock/unlock off the activity's own lifecycle (immediate, unlike the debounced
+    // ProcessLifecycleOwner). ON_STOP fires the moment the activity is no longer visible, so a quick
+    // background→foreground still re-locks. The promptInFlight guard ignores the ON_STOP that a
+    // full-screen device-credential (PIN) prompt causes, so authenticating doesn't re-lock us.
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_STOP -> if (!promptInFlight) unlocked = false
+                Lifecycle.Event.ON_START -> launchUnlockPrompt()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    // Cover the cases the ON_START observer can miss: the initial foreground that already happened
+    // before this effect registered (cold start) and a mid-session enable. If we are visible and
+    // locked, prompt now.
+    LaunchedEffect(gateActive, unlocked) {
+        if (gateActive && !unlocked &&
+            lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED)
+        ) {
+            launchUnlockPrompt()
+        }
+    }
+
+    // Re-authentication handshake: prompt before ReauthCoordinator re-logs in on token expiry.
+    DisposableEffect(activity, gateActive) {
+        if (activity != null && gateActive) {
+            appViewModel.setBiometricReauthCallback {
+                runBiometricPrompt(
+                    activity,
+                    title = "Re-authenticate",
+                    subtitle = "Your session expired. Authenticate to reconnect your account.",
+                    onSuccess = {
+                        ReauthCoordinator.completeBiometricReauth(appViewModel)
+                        appViewModel.clearPendingBiometricReauth()
+                    },
+                    onFail = {
+                        ReauthCoordinator.cancelPendingReauth()
+                        appViewModel.clearPendingBiometricReauth()
+                    }
+                )
+            }
+        }
+        onDispose { appViewModel.setBiometricReauthCallback(null) }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        content()
+        if (gateActive && !unlocked) {
+            BiometricLockOverlay(onAuthenticate = { launchUnlockPrompt() })
+        }
+    }
+}
+
+@Composable
+private fun BiometricLockOverlay(onAuthenticate: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+            modifier = Modifier.padding(32.dp)
+        ) {
+            Image(
+                painter = painterResource(id = R.mipmap.ic_launcher_foreground),
+                contentDescription = null,
+                modifier = Modifier.size(96.dp),
+                colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.onBackground)
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "Andromuks is locked",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Button(onClick = onAuthenticate) {
+                Text("Unlock")
+            }
+        }
+    }
+}

--- a/app/src/main/java/net/vrkknn/andromuks/BubbleTimelineScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/BubbleTimelineScreen.kt
@@ -563,7 +563,7 @@ fun BubbleTimelineScreen(
         context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
     }
     val authToken = remember(sharedPreferences) {
-        sharedPreferences.getString("gomuks_auth_token", "") ?: ""
+        net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPreferences)
     }
     val storedUserId = remember(sharedPreferences) {
         sharedPreferences.getString("current_user_id", "") ?: ""

--- a/app/src/main/java/net/vrkknn/andromuks/ChatBubbleActivity.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/ChatBubbleActivity.kt
@@ -484,7 +484,7 @@ private fun ChatBubbleLoadingScreen(
         // MutableState writes from background threads safely.
         val (token, homeserverUrl) = withContext(Dispatchers.IO) {
             val prefs = context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
-            prefs.getString("gomuks_auth_token", null) to prefs.getString("homeserver_url", null)
+            net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs).ifBlank { null } to prefs.getString("homeserver_url", null)
         }
 
         if (token != null && homeserverUrl != null) {

--- a/app/src/main/java/net/vrkknn/andromuks/EventContextScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/EventContextScreen.kt
@@ -57,7 +57,7 @@ fun EventContextScreen(
         context.getSharedPreferences("AndromuksAppPrefs", android.content.Context.MODE_PRIVATE)
     }
     val authToken = remember(sharedPreferences) {
-        sharedPreferences.getString("gomuks_auth_token", "") ?: ""
+        net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPreferences)
     }
     val imageToken = appViewModel.imageAuthToken.takeIf { it.isNotBlank() } ?: authToken
     val myUserId = appViewModel.currentUserId

--- a/app/src/main/java/net/vrkknn/andromuks/FCMService.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/FCMService.kt
@@ -116,7 +116,7 @@ class FCMService : FirebaseMessagingService() {
             enhancedNotificationDisplay?.let { return@withLock it }
             val display = withContext(Dispatchers.IO) {
                 val prefs = getSharedPreferences("AndromuksAppPrefs", MODE_PRIVATE)
-                val authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+                val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
                 val homeserverUrl = prefs.getString("homeserver_url", "") ?: ""
                 val imageAuthToken = prefs.getString("image_auth_token", "")
                     .takeIf { !it.isNullOrBlank() } ?: authToken

--- a/app/src/main/java/net/vrkknn/andromuks/MainActivity.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/MainActivity.kt
@@ -10,7 +10,7 @@ import android.os.Bundle
 import android.content.pm.PackageManager
 import android.os.Build
 import android.util.Log
-import androidx.activity.ComponentActivity
+import androidx.fragment.app.FragmentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
@@ -157,7 +157,7 @@ private fun rememberMorphingStartupAvatarMaskModifier(): Modifier {
     }
 }
 
-class MainActivity : ComponentActivity() {
+class MainActivity : FragmentActivity() {
     private lateinit var appViewModel: AppViewModel
     private lateinit var notificationBroadcastReceiver: BroadcastReceiver
     private lateinit var notificationActionReceiver: BroadcastReceiver
@@ -175,7 +175,7 @@ class MainActivity : ComponentActivity() {
         
         // Initialize crash handler
         CrashHandler.initialize(this)
-        
+
         // Battery-saver mode: if the service was suspended in the background, clear the
         // user-disconnected flag now that the user is actively opening the app.
         // AuthCheck downstream will handle the cold-start dial of the WebSocket and
@@ -372,7 +372,7 @@ class MainActivity : ComponentActivity() {
                             // Get homeserver URL and auth token from SharedPreferences
                             val sharedPrefs = getSharedPreferences("AndromuksAppPrefs", MODE_PRIVATE)
                             val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
-                            val authToken = sharedPrefs.getString("gomuks_auth_token", "") ?: ""
+                            val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
 
                             // Canonical fix for empty appViewModel.homeserverUrl during cold-start
                             // rendering: populate it (and the auth token) from SharedPreferences on the
@@ -641,7 +641,7 @@ class MainActivity : ComponentActivity() {
                                 // Update the notification with the sent message
                                 try {
                                     val sharedPrefs = getSharedPreferences("AndromuksAppPrefs", MODE_PRIVATE)
-                                    val authToken = sharedPrefs.getString("gomuks_auth_token", "") ?: ""
+                                    val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
                                     val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
                                     
                                     if (homeserverUrl.isNotEmpty() && authToken.isNotEmpty()) {
@@ -670,7 +670,7 @@ class MainActivity : ComponentActivity() {
                                 // Update the notification to show it's been read
                                 try {
                                     val sharedPrefs = getSharedPreferences("AndromuksAppPrefs", MODE_PRIVATE)
-                                    val authToken = sharedPrefs.getString("gomuks_auth_token", "") ?: ""
+                                    val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
                                     val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
                                     
                                     if (homeserverUrl.isNotEmpty() && authToken.isNotEmpty()) {
@@ -741,7 +741,7 @@ class MainActivity : ComponentActivity() {
                             // This prevents race conditions that cause duplicate sends
                             try {
                                 val sharedPrefs = getSharedPreferences("AndromuksAppPrefs", MODE_PRIVATE)
-                                val authToken = sharedPrefs.getString("gomuks_auth_token", "") ?: ""
+                                val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
                                 val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
                                 
                                 if (homeserverUrl.isNotEmpty() && authToken.isNotEmpty()) {
@@ -762,7 +762,7 @@ class MainActivity : ComponentActivity() {
                                     delay(200) // 200ms delay to let Android finish processing
                                     try {
                                         val sharedPrefs = getSharedPreferences("AndromuksAppPrefs", MODE_PRIVATE)
-                                        val authToken = sharedPrefs.getString("gomuks_auth_token", "") ?: ""
+                                        val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
                                         val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
                                         
                                         if (homeserverUrl.isNotEmpty() && authToken.isNotEmpty()) {
@@ -798,7 +798,7 @@ class MainActivity : ComponentActivity() {
                                 // Update the notification to show it's been read
                                 try {
                                     val sharedPrefs = getSharedPreferences("AndromuksAppPrefs", MODE_PRIVATE)
-                                    val authToken = sharedPrefs.getString("gomuks_auth_token", "") ?: ""
+                                    val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
                                     val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
                                     
                                     if (homeserverUrl.isNotEmpty() && authToken.isNotEmpty()) {
@@ -941,7 +941,7 @@ class MainActivity : ComponentActivity() {
                     // Get credentials and force reconnection
                     val sharedPrefs = getSharedPreferences("AndromuksAppPrefs", MODE_PRIVATE)
                     val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
-                    val authToken = sharedPrefs.getString("gomuks_auth_token", "") ?: ""
+                    val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
                     if (homeserverUrl.isNotEmpty() && authToken.isNotEmpty()) {
                         appViewModel.initializeWebSocketConnection(homeserverUrl, authToken)
                     } else {
@@ -1259,7 +1259,10 @@ fun AppNavigation(
 
     // Wrap NavHost in SharedTransitionLayout for shared element transitions.
     // An outer Box layers the call overlay above the nav graph.
+    // BiometricLockGate optionally overlays an app-lock and drives biometric re-auth (no-op unless
+    // the user enabled "Require biometric"); it does not wrap chat-bubble windows.
     Box(modifier = modifier) {
+    BiometricLockGate(appViewModel) {
     SharedTransitionLayout {
         NavHost(
         navController = navController,
@@ -1375,7 +1378,7 @@ fun AppNavigation(
                         ?: sharedPrefs.getString("homeserver_url", "").orEmpty()
                 val startupAuthToken =
                     appViewModel.authToken.takeIf { it.isNotBlank() }
-                        ?: sharedPrefs.getString("gomuks_auth_token", "").orEmpty()
+                        ?: net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
                 var showStartupMorphOverlay by remember(startupAvatarMxc) { mutableStateOf(false) }
                 LaunchedEffect(startupAvatarMxc) {
                     if (startupAvatarMxc != null) {
@@ -1955,5 +1958,6 @@ fun AppNavigation(
     CallOverlay(appViewModel = appViewModel)
     // Incoming call banner (zIndex 20, above the call overlay's 10).
     IncomingCallBanner(appViewModel = appViewModel)
+    } // End of BiometricLockGate content
     } // End of outer Box
 }

--- a/app/src/main/java/net/vrkknn/andromuks/NotificationImageWorker.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/NotificationImageWorker.kt
@@ -171,8 +171,7 @@ class NotificationImageWorker(
         val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
         val freshToken = sharedPrefs.getString("image_auth_token", "")
             ?.takeIf { it.isNotBlank() }
-            ?: sharedPrefs.getString("gomuks_auth_token", "")
-            ?: ""
+            ?: net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
         val batchToken = inputData.getString(KEY_IMAGE_AUTH_TOKEN) ?: ""
         val authToken = freshToken.ifBlank { inputData.getString(KEY_AUTH_TOKEN) ?: "" }
 

--- a/app/src/main/java/net/vrkknn/andromuks/NotificationReplyReceiver.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/NotificationReplyReceiver.kt
@@ -80,7 +80,7 @@ class NotificationReplyReceiver : BroadcastReceiver() {
             // Battery-saver mode: POST to the HTTP batterySaver. Works while the WebSocket is closed.
             val pendingResult = goAsync()
             val homeserverUrl = prefs.getString("homeserver_url", "") ?: ""
-            val authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+            val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
             thread(name = "batterySaver-reply") {
                 try {
                     val ok = ExecApi.sendMessage(
@@ -114,7 +114,7 @@ class NotificationReplyReceiver : BroadcastReceiver() {
                 // Android only stops the spinner when notify() is called again with the same ID.
                 val sharedPrefs = context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
                 val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
-                val authToken = sharedPrefs.getString("gomuks_auth_token", "") ?: ""
+                val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
                 EnhancedNotificationDisplay(context, homeserverUrl, authToken)
                     .updateNotificationWithReply(roomId, replyText)
             }

--- a/app/src/main/java/net/vrkknn/andromuks/ReauthCoordinator.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/ReauthCoordinator.kt
@@ -1,0 +1,139 @@
+package net.vrkknn.andromuks
+
+import android.content.Context
+import android.util.Log
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import net.vrkknn.andromuks.utils.CredentialStore
+import net.vrkknn.andromuks.utils.performHttpLogin
+import okhttp3.OkHttpClient
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Recovers from an expired gomuks session token (HTTP 401) by silently re-logging in with the
+ * credentials persisted by [CredentialStore], instead of dropping the user back to [LoginScreen].
+ *
+ * Two modes, chosen by the "Require biometric" setting:
+ *  - **Silent** (setting off): re-login happens with no user interaction.
+ *  - **Biometric** (setting on): re-login is deferred — the UI layer must run a
+ *    [androidx.biometric.BiometricPrompt] and, on success, call [completeBiometricReauth], which
+ *    decrypts the (non-auth-bound) credentials and re-logs in. See [AppViewModel.pendingBiometricReauth].
+ *
+ * A single global guard ([inProgress]) dedupes the per-ViewModel fan-out of `handleUnauthorizedError`
+ * so only one re-login runs at a time, and a cooldown prevents tight 401 → re-auth → 401 loops.
+ */
+object ReauthCoordinator {
+    private const val TAG = "ReauthCoordinator"
+    private const val PREFS = "AndromuksAppPrefs"
+    private const val COOLDOWN_MS = 5_000L
+
+    private val inProgress = AtomicBoolean(false)
+    @Volatile private var lastFailureMs = 0L
+
+    private val client by lazy { OkHttpClient.Builder().build() }
+
+    /**
+     * Entry point from [AppViewModel.handleUnauthorizedError]. Returns true when a re-auth attempt
+     * was started or is pending user authentication — in that case the caller must NOT clear the
+     * session. Returns false when no recovery is possible (no stored credentials, or still in the
+     * post-failure cooldown), signalling the caller to fall back to clear-and-login.
+     */
+    fun attempt(appViewModel: AppViewModel): Boolean {
+        val context = appViewModel.appContext ?: return false
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+        if (!CredentialStore.hasCredentials(prefs)) {
+            Log.i(TAG, "No stored credentials; cannot silently re-auth")
+            return false
+        }
+
+        // A recent failure means the password is likely genuinely invalid (changed/revoked).
+        // Bail so the caller falls through to the login screen instead of looping.
+        if (System.currentTimeMillis() - lastFailureMs < COOLDOWN_MS) {
+            Log.w(TAG, "Within post-failure cooldown; not retrying re-auth")
+            return false
+        }
+
+        if (!inProgress.compareAndSet(false, true)) {
+            Log.d(TAG, "Re-auth already in progress; suppressing duplicate 401")
+            return true
+        }
+
+        if (prefs.getBoolean("require_biometric_unlock", false)) {
+            // The user opted to authenticate before re-auth. Hand off to the UI to run a
+            // BiometricPrompt; on success it calls completeBiometricReauth().
+            Log.i(TAG, "Biometric required; requesting authentication from UI before re-auth")
+            appViewModel.requestBiometricReauth()
+            return true
+        }
+
+        startReauth(appViewModel, prefs)
+        return true
+    }
+
+    /**
+     * Completes a biometric-gated re-auth once the UI's BiometricPrompt has authenticated the user.
+     * The credentials are decrypted here (Key B is not auth-bound), then re-login proceeds.
+     */
+    fun completeBiometricReauth(appViewModel: AppViewModel) {
+        val context = appViewModel.appContext ?: return
+        val prefs = context.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        // attempt() already set inProgress for the biometric path.
+        startReauth(appViewModel, prefs)
+    }
+
+    /** Called by the UI if the biometric prompt is cancelled/failed, releasing the guard. */
+    fun cancelPendingReauth() {
+        inProgress.set(false)
+    }
+
+    private fun startReauth(
+        appViewModel: AppViewModel,
+        prefs: android.content.SharedPreferences
+    ) {
+        val creds = CredentialStore.loadCredentials(prefs)
+        if (creds == null) {
+            Log.e(TAG, "Stored credentials present but decrypt failed; falling back to login")
+            inProgress.set(false)
+            appViewModel.clearCredentialsAndNavigateToLogin()
+            return
+        }
+        val username = creds.username
+        val password = creds.password
+        val url = prefs.getString("homeserver_url", "") ?: ""
+        if (url.isBlank()) {
+            Log.e(TAG, "No homeserver_url for re-auth")
+            inProgress.set(false)
+            appViewModel.clearCredentialsAndNavigateToLogin()
+            return
+        }
+        Log.i(TAG, "Starting silent re-auth for $username @ $url")
+        appViewModel.logActivity("401 Unauthorized - Attempting silent re-auth", null)
+
+        // performHttpLogin re-persists the new token (encrypted) and the credentials on success.
+        performHttpLogin(
+            url = url,
+            username = username,
+            password = password,
+            client = client,
+            scope = appViewModel.viewModelScope,
+            sharedPreferences = prefs,
+            onSuccess = {
+                inProgress.set(false)
+                lastFailureMs = 0L
+                Log.i(TAG, "Silent re-auth succeeded; reconnecting WebSocket")
+                appViewModel.logActivity("Silent re-auth succeeded", null)
+                val newToken = CredentialStore.getAuthToken(prefs)
+                appViewModel.reconnectAfterReauth(url, newToken)
+            },
+            onFailure = {
+                inProgress.set(false)
+                lastFailureMs = System.currentTimeMillis()
+                Log.w(TAG, "Silent re-auth failed; clearing credentials and navigating to login")
+                appViewModel.logActivity("Silent re-auth failed - clearing credentials", null)
+                appViewModel.clearCredentialsAndNavigateToLogin()
+            }
+        )
+    }
+}

--- a/app/src/main/java/net/vrkknn/andromuks/RoomListScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/RoomListScreen.kt
@@ -264,7 +264,7 @@ fun RoomListScreen(
     val context = LocalContext.current
     val hapticFeedback = LocalHapticFeedback.current
     val sharedPreferences = remember(context) { context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE) }
-    val authToken = remember(sharedPreferences) { sharedPreferences.getString("gomuks_auth_token", "") ?: "" }
+    val authToken = remember(sharedPreferences) { net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPreferences) }
     val uiState by appViewModel.rememberRoomListUiState()
     val connectionState by SyncRepository.connectionState.collectAsState()
     val imageToken = uiState.imageAuthToken.takeIf { it.isNotBlank() } ?: authToken

--- a/app/src/main/java/net/vrkknn/andromuks/RoomTimelineScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/RoomTimelineScreen.kt
@@ -770,7 +770,7 @@ fun RoomTimelineScreen(
             context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
         }
     val authToken =
-        remember(sharedPreferences) { sharedPreferences.getString("gomuks_auth_token", "") ?: "" }
+        remember(sharedPreferences) { net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPreferences) }
     val myUserId = appViewModel.currentUserId
     val homeserverUrlFromPrefs = remember(sharedPreferences) { sharedPreferences.getString("homeserver_url", "") ?: "" }
     val homeserverUrl = appViewModel.homeserverUrl.ifEmpty { homeserverUrlFromPrefs }

--- a/app/src/main/java/net/vrkknn/andromuks/ServiceStartWorker.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/ServiceStartWorker.kt
@@ -70,7 +70,7 @@ class ServiceStartWorker(
             // Check if we have credentials (user is logged in)
             val prefs = applicationContext.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
             val homeserverUrl = prefs.getString("homeserver_url", "") ?: ""
-            val authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+            val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
             
             if (homeserverUrl.isEmpty() || authToken.isEmpty()) {
                 if (BuildConfig.DEBUG) Log.d(TAG, "No credentials found - user not logged in, skipping service start")

--- a/app/src/main/java/net/vrkknn/andromuks/SettingsCoordinator.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/SettingsCoordinator.kt
@@ -118,6 +118,21 @@ internal class SettingsCoordinator(private val vm: AppViewModel) {
         }
     }
 
+    fun setRequireBiometricUnlock(enabled: Boolean) = with(vm) {
+        requireBiometricUnlock = enabled
+
+        appContext?.let { context ->
+            val prefs = context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
+            prefs.edit()
+                .putBoolean("require_biometric_unlock", enabled)
+                .apply()
+            if (BuildConfig.DEBUG) android.util.Log.d(
+                "Andromuks",
+                "AppViewModel: Saved requireBiometricUnlock setting: $enabled"
+            )
+        }
+    }
+
     fun toggleMoveReadReceiptsToEdge() = with(vm) {
         moveReadReceiptsToEdge = !moveReadReceiptsToEdge
 
@@ -432,6 +447,7 @@ internal class SettingsCoordinator(private val vm: AppViewModel) {
             showAllRoomListTabs = prefs.getBoolean("show_all_room_list_tabs", false)
             moveReadReceiptsToEdge = prefs.getBoolean("move_read_receipts_to_edge", false)
             trimLongDisplayNames = prefs.getBoolean("trim_long_display_names", true)
+            requireBiometricUnlock = prefs.getBoolean("require_biometric_unlock", false)
             showLinkPreviews = prefs.getBoolean("show_link_previews", true)
             sendLinkPreviews = prefs.getBoolean("send_link_previews", true)
             elementCallBaseUrl = prefs.getString("element_call_base_url", "") ?: ""

--- a/app/src/main/java/net/vrkknn/andromuks/SettingsScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/SettingsScreen.kt
@@ -220,6 +220,57 @@ fun SettingsScreen(
                 }
             }
 
+            // ── Security ──────────────────────────────────────────────────────
+            Text(
+                text = "Security",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.padding(top = 16.dp)
+            )
+
+            val context = LocalContext.current
+            val biometricAvailable = remember { canAuthenticate(context) }
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Require biometric unlock",
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.Medium
+                        )
+                        Text(
+                            text = if (biometricAvailable) {
+                                "Ask for your fingerprint, face, or device PIN each time the app comes to the " +
+                                    "foreground. This same authentication is also required before the app silently " +
+                                    "re-logs in when your session expires — so unlocking re-authenticates your " +
+                                    "account, not just the screen. Chat bubbles are not locked."
+                            } else {
+                                "Unavailable: no fingerprint, face, or device lock is set up on this device. " +
+                                    "Enrol a biometric or screen lock in system settings to use this."
+                            },
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+
+                    Switch(
+                        checked = appViewModel.requireBiometricUnlock,
+                        enabled = biometricAvailable,
+                        onCheckedChange = { appViewModel.setRequireBiometricUnlock(it) }
+                    )
+                }
+            }
+
             // ── Connection Mode ──────────────────────────────────────────────
             Text(
                 text = "Connection Mode",

--- a/app/src/main/java/net/vrkknn/andromuks/ShortcutActivity.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/ShortcutActivity.kt
@@ -199,7 +199,7 @@ fun ShortcutNavigation(roomId: String) {
     LaunchedEffect(Unit) {
         val sharedPrefs = context.getSharedPreferences("AndromuksAppPrefs", android.content.Context.MODE_PRIVATE)
         val homeserverUrl = sharedPrefs.getString("homeserver_url", "") ?: ""
-        val authToken = sharedPrefs.getString("gomuks_auth_token", "") ?: ""
+        val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPrefs)
 
         // Expose homeserver URL and auth token on the ViewModel so that any composable
         // using appViewModel.homeserverUrl / appViewModel.authToken directly (e.g.

--- a/app/src/main/java/net/vrkknn/andromuks/SimplerRoomListScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/SimplerRoomListScreen.kt
@@ -68,7 +68,7 @@ fun SimplerRoomListScreen(
             context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
         }
     val authToken =
-        remember(sharedPreferences) { sharedPreferences.getString("gomuks_auth_token", "") ?: "" }
+        remember(sharedPreferences) { net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPreferences) }
     val uiState by appViewModel.rememberRoomListUiState()
     val imageToken = uiState.imageAuthToken.takeIf { it.isNotBlank() } ?: authToken
     val homeserverUrl = appViewModel.homeserverUrl

--- a/app/src/main/java/net/vrkknn/andromuks/SyncRepository.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/SyncRepository.kt
@@ -468,8 +468,9 @@ object SyncRepository {
     fun hasCredentials(context: Context): Boolean {
         val prefs = context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
         val h = prefs.getString("homeserver_url", "") ?: ""
-        val t = prefs.getString("gomuks_auth_token", "") ?: ""
-        return h.isNotEmpty() && t.isNotEmpty()
+        // Presence check only — avoid a Keystore decrypt on this hot, main-thread path.
+        val hasToken = net.vrkknn.andromuks.utils.CredentialStore.hasAuthToken(prefs)
+        return h.isNotEmpty() && hasToken
     }
 
     fun emitEvent(event: SyncEvent) {

--- a/app/src/main/java/net/vrkknn/andromuks/ThreadViewerScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/ThreadViewerScreen.kt
@@ -310,7 +310,7 @@ fun ThreadViewerScreen(
             context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
         }
     val authToken =
-        remember(sharedPreferences) { sharedPreferences.getString("gomuks_auth_token", "") ?: "" }
+        remember(sharedPreferences) { net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(sharedPreferences) }
     val imageToken = appViewModel.imageAuthToken.takeIf { it.isNotBlank() } ?: authToken
     val myUserId = appViewModel.currentUserId
     val homeserverUrlFromPrefs = remember(sharedPreferences) { sharedPreferences.getString("homeserver_url", "") ?: "" }

--- a/app/src/main/java/net/vrkknn/andromuks/ViewModelLifecycleCoordinator.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/ViewModelLifecycleCoordinator.kt
@@ -249,7 +249,7 @@ internal class ViewModelLifecycleCoordinator(private val vm: AppViewModel) {
                 if (!pingFired) {
                     val prefs = ctx.getSharedPreferences("AndromuksAppPrefs", android.content.Context.MODE_PRIVATE)
                     val homeserverUrl = prefs.getString("homeserver_url", "") ?: ""
-                    val authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+                    val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
                     if (BuildConfig.DEBUG) android.util.Log.i(
                         "Andromuks",
                         "AppViewModel: Resume health check — pingNowWithWatchdog returned false → re-dialling WebSocket",

--- a/app/src/main/java/net/vrkknn/andromuks/WebSocketHealthCheckWorker.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/WebSocketHealthCheckWorker.kt
@@ -83,7 +83,7 @@ class WebSocketHealthCheckWorker(
             // Check if we have credentials (user is logged in)
             val prefs = applicationContext.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
             val homeserverUrl = prefs.getString("homeserver_url", "") ?: ""
-            val authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+            val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
 
             if (homeserverUrl.isEmpty() || authToken.isEmpty()) {
                 if (BuildConfig.DEBUG) Log.d(TAG, "No credentials found - user not logged in, skipping health check")

--- a/app/src/main/java/net/vrkknn/andromuks/WebSocketService.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/WebSocketService.kt
@@ -353,7 +353,7 @@ class WebSocketService : Service() {
                 try {
                     val prefs = serviceInstance.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
                     val homeserverUrl = prefs.getString("homeserver_url", "") ?: ""
-                    val authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+                    val authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
                     
                     if (homeserverUrl.isEmpty() || authToken.isEmpty()) {
                         android.util.Log.w("WebSocketService", "Cannot reconnect - missing credentials in SharedPreferences")

--- a/app/src/main/java/net/vrkknn/andromuks/utils/CredentialStore.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/utils/CredentialStore.kt
@@ -1,0 +1,256 @@
+package net.vrkknn.andromuks.utils
+
+import android.content.SharedPreferences
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import android.util.Log
+import net.vrkknn.andromuks.BuildConfig
+import java.security.KeyStore
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import org.json.JSONObject
+
+/**
+ * Encrypts sensitive auth material at rest using AES-256-GCM keys held in the Android Keystore.
+ *
+ * Two independent keys are used:
+ *  - **Key A** ([TOKEN_KEY_ALIAS]) — wraps the gomuks session token.
+ *  - **Key B** ([CRED_KEY_ALIAS]) — wraps the username + password for silent re-auth on token expiry.
+ *
+ * Both keys are non-auth-bound so they can be decrypted by background workers (FCM wake-ups,
+ * WorkManager) where no user is present, and so silent re-auth works without UI. The "require
+ * biometric" feature is enforced as a separate UI gate (a [androidx.biometric.BiometricPrompt] that
+ * must pass before re-auth proceeds), not by binding these keys — see [ReauthCoordinator] and the
+ * app-lock gate. This keeps re-auth and the settings toggle simple while still requiring a present,
+ * authenticated user before re-authentication when the user opts in.
+ *
+ * The keys being non-exportable in the Android Keystore is the at-rest protection; the realistic
+ * trust boundary is full-disk encryption plus the app sandbox.
+ *
+ * `homeserver_url` is intentionally left as plaintext in SharedPreferences: it is read in many
+ * non-sensitive places and is not a secret.
+ *
+ * Ciphertext is stored as `Base64(iv):Base64(ciphertext)` in the same `AndromuksAppPrefs` store.
+ * The GCM tag (128 bits) is appended to the ciphertext by the JCE provider.
+ */
+object CredentialStore {
+    private const val TAG = "CredentialStore"
+
+    private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+    private const val TOKEN_KEY_ALIAS = "andromuks_token_key_v1"
+    private const val CRED_KEY_ALIAS = "andromuks_cred_key_v1"
+
+    private const val TRANSFORMATION = "AES/GCM/NoPadding"
+    private const val GCM_TAG_BITS = 128
+    private const val KEY_SIZE = 256
+
+    // Ciphertext pref keys.
+    private const val P_ENC_TOKEN = "enc_token"
+    private const val P_ENC_CREDS = "enc_credentials"
+
+    // Legacy plaintext key (pre-encryption builds wrote the token here).
+    private const val LEGACY_TOKEN = "gomuks_auth_token"
+
+    data class StoredCredentials(val username: String, val password: String)
+
+    // In-memory cache of the decrypted token. A Keystore decrypt costs ~20 ms of disk I/O + crypto,
+    // and getAuthToken() is called on hot, main-thread paths (sync processing, composition, image
+    // loading), so without this every call would block the main thread and trip StrictMode. The
+    // cache is the single source after first read; every write path below keeps it in sync, and
+    // CredentialStore is the only writer of the token, so it can never go stale.
+    @Volatile private var cachedToken: String? = null
+
+    // ── Session token (Key A, never auth-bound) ──────────────────────────────
+
+    /**
+     * Returns the gomuks session token, decrypting the at-rest blob on first use and caching it.
+     * Falls back to the legacy plaintext key so an in-flight migration (or a failed decrypt) never
+     * strands callers that run in the background. Returns "" when no token is stored.
+     */
+    fun getAuthToken(prefs: SharedPreferences): String {
+        cachedToken?.let { return it }
+        synchronized(this) {
+            cachedToken?.let { return it }
+            val blob = prefs.getString(P_ENC_TOKEN, null)
+            val token = if (!blob.isNullOrBlank()) {
+                decrypt(getOrCreateKey(TOKEN_KEY_ALIAS), blob) ?: run {
+                    Log.w(TAG, "Token decrypt failed; falling back to legacy plaintext if present")
+                    prefs.getString(LEGACY_TOKEN, "") ?: ""
+                }
+            } else {
+                prefs.getString(LEGACY_TOKEN, "") ?: ""
+            }
+            cachedToken = token
+            return token
+        }
+    }
+
+    /**
+     * Whether a session token exists, **without** decrypting it (no Keystore access). Use this for
+     * presence checks on hot paths instead of `getAuthToken(prefs).isNotEmpty()`.
+     */
+    fun hasAuthToken(prefs: SharedPreferences): Boolean {
+        cachedToken?.let { return it.isNotEmpty() }
+        return !prefs.getString(P_ENC_TOKEN, null).isNullOrBlank() ||
+            !prefs.getString(LEGACY_TOKEN, null).isNullOrBlank()
+    }
+
+    /** Encrypts and stores the token under Key A, removing any legacy plaintext copy. */
+    fun persistAuthToken(prefs: SharedPreferences, token: String) {
+        val key = getOrCreateKey(TOKEN_KEY_ALIAS)
+        val blob = encrypt(key, token)
+        if (blob == null) {
+            // Keystore unavailable — degrade to legacy plaintext rather than losing the session.
+            Log.w(TAG, "Token encryption failed; storing legacy plaintext as fallback")
+            prefs.edit().putString(LEGACY_TOKEN, token).remove(P_ENC_TOKEN).apply()
+            cachedToken = token
+            return
+        }
+        prefs.edit().putString(P_ENC_TOKEN, blob).remove(LEGACY_TOKEN).apply()
+        cachedToken = token
+    }
+
+    /** Removes both the encrypted token and any legacy plaintext copy. */
+    fun clearAuthToken(editor: SharedPreferences.Editor) {
+        editor.remove(P_ENC_TOKEN)
+        editor.remove(LEGACY_TOKEN)
+        cachedToken = ""
+    }
+
+    /**
+     * Warms [cachedToken] off the main thread so the first real read (often during composition or
+     * sync processing on the main thread) is a cache hit. Safe to call from a background thread at
+     * app startup.
+     */
+    fun warmTokenCache(prefs: SharedPreferences) {
+        if (cachedToken == null) getAuthToken(prefs)
+    }
+
+    /**
+     * One-shot migration: if a legacy plaintext token exists and no encrypted blob does, re-encrypt
+     * it and drop the plaintext. Safe to call on every app start.
+     */
+    fun migratePlaintextTokenIfNeeded(prefs: SharedPreferences) {
+        val legacy = prefs.getString(LEGACY_TOKEN, null)
+        if (legacy.isNullOrBlank()) return
+        if (!prefs.getString(P_ENC_TOKEN, null).isNullOrBlank()) {
+            // Encrypted copy already present; just drop the stale plaintext.
+            prefs.edit().remove(LEGACY_TOKEN).apply()
+            return
+        }
+        if (BuildConfig.DEBUG) Log.d(TAG, "Migrating legacy plaintext token to encrypted storage")
+        persistAuthToken(prefs, legacy)
+    }
+
+    // ── Credentials (Key B) ──────────────────────────────────────────────────
+
+    fun hasCredentials(prefs: SharedPreferences): Boolean =
+        !prefs.getString(P_ENC_CREDS, null).isNullOrBlank()
+
+    /** Encrypts and stores the login credentials for silent re-auth. Returns false on failure. */
+    fun persistCredentials(
+        prefs: SharedPreferences,
+        username: String,
+        password: String
+    ): Boolean {
+        val key = getOrCreateKey(CRED_KEY_ALIAS) ?: return false
+        val json = JSONObject().apply {
+            put("u", username)
+            put("p", password)
+        }.toString()
+        val blob = encrypt(key, json) ?: return false
+        prefs.edit().putString(P_ENC_CREDS, blob).apply()
+        return true
+    }
+
+    /** Decrypts and returns the stored credentials, or null when absent / on decrypt failure. */
+    fun loadCredentials(prefs: SharedPreferences): StoredCredentials? {
+        val blob = prefs.getString(P_ENC_CREDS, null) ?: return null
+        val key = getKey(CRED_KEY_ALIAS) ?: return null
+        val json = decrypt(key, blob) ?: return null
+        return parseCredentials(json)
+    }
+
+    fun clearCredentials(prefs: SharedPreferences) {
+        prefs.edit().remove(P_ENC_CREDS).apply()
+        deleteKey(CRED_KEY_ALIAS)
+    }
+
+    private fun parseCredentials(json: String): StoredCredentials? = try {
+        val o = JSONObject(json)
+        StoredCredentials(o.optString("u", ""), o.optString("p", ""))
+    } catch (e: Exception) {
+        Log.e(TAG, "Malformed credential JSON", e)
+        null
+    }
+
+    // ── Keystore + crypto primitives ─────────────────────────────────────────
+
+    /** Encrypts [plaintext] with a fresh random IV. Returns `Base64(iv):Base64(ct)` or null. */
+    private fun encrypt(key: SecretKey?, plaintext: String): String? {
+        if (key == null) return null
+        return try {
+            val cipher = Cipher.getInstance(TRANSFORMATION).apply { init(Cipher.ENCRYPT_MODE, key) }
+            val ct = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))
+            Base64.encodeToString(cipher.iv, Base64.NO_WRAP) + ":" + Base64.encodeToString(ct, Base64.NO_WRAP)
+        } catch (e: Exception) {
+            Log.e(TAG, "Encryption failed", e)
+            null
+        }
+    }
+
+    /** Decrypts a `Base64(iv):Base64(ct)` blob with a non-auth-bound key. Returns null on failure. */
+    private fun decrypt(key: SecretKey?, blob: String): String? {
+        if (key == null) return null
+        return try {
+            val iv = Base64.decode(blob.substringBefore(':'), Base64.NO_WRAP)
+            val ct = Base64.decode(blob.substringAfter(':'), Base64.NO_WRAP)
+            val cipher = Cipher.getInstance(TRANSFORMATION).apply {
+                init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+            }
+            String(cipher.doFinal(ct), Charsets.UTF_8)
+        } catch (e: Exception) {
+            Log.e(TAG, "Decryption failed", e)
+            null
+        }
+    }
+
+    private fun getKey(alias: String): SecretKey? = try {
+        val ks = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        ks.getKey(alias, null) as? SecretKey
+    } catch (e: Exception) {
+        Log.e(TAG, "Failed to load key $alias", e)
+        null
+    }
+
+    private fun getOrCreateKey(alias: String): SecretKey? {
+        getKey(alias)?.let { return it }
+        return try {
+            val generator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+            val spec = KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT
+            )
+                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                .setKeySize(KEY_SIZE)
+                .build()
+            generator.init(spec)
+            generator.generateKey()
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to create key $alias", e)
+            null
+        }
+    }
+
+    private fun deleteKey(alias: String) {
+        try {
+            KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }.deleteEntry(alias)
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to delete key $alias", e)
+        }
+    }
+}

--- a/app/src/main/java/net/vrkknn/andromuks/utils/ExecApi.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/utils/ExecApi.kt
@@ -66,7 +66,7 @@ object ExecApi {
         val prefs = context.getSharedPreferences("AndromuksAppPrefs", Context.MODE_PRIVATE)
         return Credentials(
             homeserverUrl = prefs.getString("homeserver_url", "") ?: "",
-            authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+            authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
         )
     }
 

--- a/app/src/main/java/net/vrkknn/andromuks/utils/ImageLoaderSingleton.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/utils/ImageLoaderSingleton.kt
@@ -33,7 +33,7 @@ object ImageLoaderSingleton {
     // very first image request, before the first composable sets authToken directly.
     fun initFromStorage(context: Context) {
         val prefs = context.getSharedPreferences("AndromuksAppPrefs", android.content.Context.MODE_PRIVATE)
-        authToken = prefs.getString("gomuks_auth_token", "") ?: ""
+        authToken = net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(prefs)
     }
 
     // QUALITY IMPROVEMENT: Optimized cache settings for better quality
@@ -83,8 +83,7 @@ object ImageLoaderSingleton {
                     // Read live holder first; fall back to SharedPreferences for the narrow
                     // window before updateAuthToken has been called in the current process.
                     val token = authToken.takeIf { it.isNotBlank() }
-                        ?: (appContext.getSharedPreferences("AndromuksAppPrefs", android.content.Context.MODE_PRIVATE)
-                            .getString("gomuks_auth_token", "") ?: "")
+                        ?: net.vrkknn.andromuks.utils.CredentialStore.getAuthToken(appContext.getSharedPreferences("AndromuksAppPrefs", android.content.Context.MODE_PRIVATE))
                     var builder = req.newBuilder()
                     if (token.isNotBlank()) {
                         builder = builder.header("Cookie", "gomuks_auth=$token")

--- a/app/src/main/java/net/vrkknn/andromuks/utils/NetworkUtils.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/utils/NetworkUtils.kt
@@ -454,10 +454,19 @@ fun performHttpLogin(
                     val jsonResponse = JSONObject(responseBodyString)
                     val receivedToken = jsonResponse.optString("token", "")
                     if (receivedToken != null) {
+                        // Token is encrypted at rest (Key A) so background workers can decrypt it.
+                        // homeserver_url stays plaintext (not a secret, read in many places).
+                        // Credentials are stored encrypted for silent re-auth on token expiry; the
+                        // biometric requirement is enforced as a UI gate, not by key binding.
+                        CredentialStore.persistAuthToken(sharedPreferences, receivedToken)
                         sharedPreferences.edit {
-                            putString("gomuks_auth_token", receivedToken)
                             putString("homeserver_url", url)
                         }
+                        CredentialStore.persistCredentials(
+                            sharedPreferences,
+                            username = username,
+                            password = password
+                        )
                         if (BuildConfig.DEBUG) Log.d(
                             "LoginScreen",
                             "Token and server base URL saved to SharedPreferences."

--- a/docs/CREDENTIALS_REAUTH.md
+++ b/docs/CREDENTIALS_REAUTH.md
@@ -1,0 +1,146 @@
+# Secure Credentials, Silent Re-auth & Biometric Lock
+
+This document covers how Andromuks stores auth material at rest, silently recovers from an expired
+session token, and optionally gates the app behind biometric authentication.
+
+## Problem
+
+The gomuks session token (`gomuks_auth_token`) returned by `/auth/login` can expire. Previously the
+token lived as **plaintext** in `AndromuksAppPrefs` SharedPreferences, and on a 401 the app wiped
+credentials and dropped the user back to `LoginScreen` — re-entering the homeserver URL, username,
+and password every time the token lapsed.
+
+The goals:
+
+1. Encrypt the token (and now the login credentials) at rest.
+2. On token expiry, silently re-log in with stored credentials instead of forcing a manual login.
+3. Optionally require biometric/device-credential authentication to open the app and before re-auth.
+
+---
+
+## `CredentialStore` (`utils/CredentialStore.kt`)
+
+Encrypts sensitive auth material with **AES-256-GCM** keys held in the **Android Keystore** (keys are
+non-exportable; the realistic trust boundary is full-disk encryption + the app sandbox).
+
+| Key | Alias | Wraps | Auth-bound? |
+|---|---|---|---|
+| Key A | `andromuks_token_key_v1` | gomuks session token | No |
+| Key B | `andromuks_cred_key_v1` | username + password (JSON blob) | No |
+
+Both keys are **non-auth-bound** so background workers (FCM wake-ups, WorkManager) can decrypt where
+no user is present, and so silent re-auth works without UI. `homeserver_url` is intentionally left
+plaintext — it is read in many non-sensitive places and is not a secret.
+
+Ciphertext is stored as `Base64(iv):Base64(ciphertext)` in `AndromuksAppPrefs` under `enc_token` and
+`enc_credentials`. The 128-bit GCM tag is appended to the ciphertext by the JCE provider.
+
+### In-memory token cache (StrictMode / performance)
+
+A Keystore decrypt costs ~20 ms of disk I/O + crypto, and `getAuthToken()` is called on hot,
+main-thread paths (sync processing, Compose composition, the Coil image interceptor). To avoid
+blocking the main thread (and a StrictMode `DiskReadViolation` flood), the decrypted token is held in
+a `@Volatile` in-memory cache:
+
+- `getAuthToken(prefs)` decrypts once, then serves from cache. `CredentialStore` is the **only**
+  writer of the token, so the cache can never go stale.
+- `hasAuthToken(prefs)` is a **presence check with no decrypt** (just checks the blob exists) — use it
+  for existence tests on hot paths instead of `getAuthToken(...).isNotEmpty()`. `SyncRepository.hasCredentials`
+  uses this.
+- `warmTokenCache(prefs)` decrypts off the main thread so the first real read is a cache hit.
+  Called from `AndromuksApplication.onCreate` on `applicationScope` (`Dispatchers.Default`), right
+  after `migratePlaintextTokenIfNeeded`.
+
+### Migration
+
+`migratePlaintextTokenIfNeeded(prefs)` re-encrypts any legacy plaintext `gomuks_auth_token` and drops
+the plaintext. It runs **off the main thread** in `AndromuksApplication.onCreate`. `getAuthToken`
+also falls back to the legacy plaintext key, so an in-flight migration (or a failed decrypt) never
+strands callers.
+
+### Token read sites
+
+Every read of `gomuks_auth_token` across the app (services, WorkManager workers, screens,
+`ImageLoaderSingleton`, `ExecApi`, …) routes through `CredentialStore.getAuthToken(prefs)`. The login
+write path (`performHttpLogin`) and the 401-clear path (`AppViewModel.clearCredentialsAndNavigateToLogin`)
+go through `persistAuthToken` / `clearAuthToken`. There are no remaining raw `getString("gomuks_auth_token")`
+reads outside `CredentialStore`.
+
+---
+
+## Silent re-auth (`ReauthCoordinator.kt`)
+
+On HTTP 401 (`NetworkUtils` WebSocket `onFailure`), `AppViewModel.handleUnauthorizedError()` now
+delegates to `ReauthCoordinator.attempt(this)` **before** clearing the session:
+
+1. **No stored credentials** → returns false → `clearCredentialsAndNavigateToLogin()` (legacy behaviour).
+2. **Biometric required** (the "Require biometric" setting is on) → `appViewModel.requestBiometricReauth()`
+   asks the UI to authenticate first; on success the UI calls `completeBiometricReauth()`.
+3. **Otherwise (silent)** → decrypt credentials → `performHttpLogin` → on success swap the new token
+   and `reconnectAfterReauth(url, token)` (drops the stale `ws_run_id` for a clean cold-start sync);
+   on failure → `clearCredentialsAndNavigateToLogin()` (genuinely changed/revoked password).
+
+A global `inProgress` guard dedupes the per-ViewModel fan-out of `handleUnauthorizedError`, and a 5 s
+post-failure cooldown prevents tight 401 → re-auth → 401 loops.
+
+---
+
+## Biometric lock + re-auth gate (`BiometricLock.kt`)
+
+`BiometricLockGate` wraps `MainActivity`'s nav graph (and the call overlays, so the lock covers them).
+It is **not** wrapped around `BubbleTimelineScreen` / `ChatBubbleActivity`, so chat bubbles are never
+locked. `MainActivity` is a `FragmentActivity` (required by `androidx.biometric.BiometricPrompt`).
+
+Two behaviours, both active only when **`requireBiometricUnlock`** is on **and** the device can
+authenticate (`canAuthenticate()` → strong biometric or device credential):
+
+1. **App lock** — a full-screen overlay shown on cold start, on every foreground return, and
+   immediately when the user enables the setting. Dismissed by a `BiometricPrompt`.
+2. **Re-auth gate** — registers `AppViewModel.setBiometricReauthCallback`, so a token expiry prompts
+   *"Your session expired. Authenticate to reconnect your account."* before `ReauthCoordinator`
+   re-logs in. This is what enforces "authenticate **before** we re-authenticate".
+
+### Design decision: UI gate, not key binding
+
+The biometric requirement is enforced as a **UI gate**, not by binding Key B to user authentication.
+Auth-bound keys would have been cryptographically stronger but break two things: background silent
+re-auth (no user present during an FCM wake-up) and toggling the setting off (can't re-wrap without a
+prompt). Keeping the keys non-auth-bound keeps re-auth and the toggle simple; biometric strength comes
+from the gate. Tradeoff: credentials at rest are protected by the non-exportable Keystore key + app
+sandbox + FDE, rather than a per-use biometric crypto binding.
+
+### Robustness notes (learned the hard way)
+
+- **Read the setting synchronously from prefs**, not the async-loaded `AppViewModel` field — otherwise
+  a cold start composes the gate before `requireBiometricUnlock` loads (default false) and never locks.
+  `appViewModel.requireBiometricUnlock` is observed only as a recomposition signal for runtime toggles.
+- **Drive lock/unlock off the activity's own lifecycle**, not `ProcessLifecycleOwner` — the latter is
+  debounced, so a quick background→foreground would skip the prompt. `ON_STOP` re-locks immediately;
+  `ON_START` launches the prompt. A `promptInFlight` guard ignores the `ON_STOP` a full-screen PIN
+  prompt causes (so authenticating doesn't bounce the lock back on).
+- **Never launch the prompt from the background** — only on `ON_START`/while `STARTED`. Launching while
+  stopped wedges `BiometricPrompt`.
+- `runBiometricPrompt` wraps `authenticate()` in try/catch (routes to `onFail`) and adds a negative
+  button on API < 30 (where `BIOMETRIC_STRONG | DEVICE_CREDENTIAL` is unsupported).
+
+---
+
+## Settings
+
+`SettingsScreen` has a **Security** section with a "Require biometric unlock" switch, disabled (with
+an explanation) when no biometric/lock is enrolled. The setting persists to `require_biometric_unlock`
+and is exposed via `AppViewModel.setRequireBiometricUnlock` / `SettingsCoordinator`.
+
+---
+
+## Files
+
+| File | Role |
+|---|---|
+| `utils/CredentialStore.kt` | Keystore AES-GCM encrypt/decrypt, token cache, migration |
+| `ReauthCoordinator.kt` | Silent / biometric-gated re-login on 401 |
+| `BiometricLock.kt` | `BiometricLockGate`, `runBiometricPrompt`, `canAuthenticate` |
+| `AppViewModel.kt` | `handleUnauthorizedError`, `clearCredentialsAndNavigateToLogin`, `reconnectAfterReauth`, biometric callback + `requireBiometricUnlock` |
+| `AndromuksApplication.kt` | Off-main migration + token cache warm |
+| `utils/NetworkUtils.kt` | `performHttpLogin` persists encrypted token + credentials |
+| `SettingsScreen.kt` / `SettingsCoordinator.kt` | Security section + setting persistence |


### PR DESCRIPTION
## What & why

Previously the gomuks session token lived as **plaintext** in SharedPreferences, and when it expired the app wiped credentials and forced a full manual re-login (homeserver URL + username + password). This change encrypts auth material at rest and silently recovers from token expiry, with an optional biometric lock.

## Changes

**Encryption at rest — `CredentialStore`**
- AES-256-GCM via the Android Keystore. **Key A** wraps the session token, **Key B** wraps username+password. Both non-auth-bound so background workers (FCM, WorkManager) can decrypt.
- All **35** `gomuks_auth_token` read sites now route through `getAuthToken()`. `homeserver_url` stays plaintext (not secret).
- One-shot migration of the legacy plaintext token, with a plaintext fallback so it can't strand background callers.

**Performance / StrictMode**
- In-memory token cache (one Keystore decrypt per process), a no-decrypt `hasAuthToken()` presence check for hot paths, and an off-main migration + cache warm in `AndromuksApplication`. Fixes a StrictMode `DiskReadViolation` flood from per-call Keystore I/O on the main thread.

**Silent re-auth — `ReauthCoordinator`**
- On HTTP 401: decrypt stored credentials → re-login → swap token → reconnect WebSocket, instead of going to `LoginScreen`. Falls back to login only if the re-login itself fails (changed/revoked password). Global guard + 5 s cooldown prevent 401→retry loops.

**Biometric lock + re-auth gate — `BiometricLock`**
- Optional full-screen app-lock on cold start / every foreground / on enable, dismissed by `BiometricPrompt` (biometric or device PIN). Also prompts before re-auth on token expiry.
- Excluded from chat bubbles. `MainActivity` → `FragmentActivity` (BiometricPrompt requirement).
- Lifecycle-driven (not debounced `ProcessLifecycleOwner`); setting read synchronously from prefs so cold start locks correctly.

**Settings**
- New "Security" section with a "Require biometric unlock" switch, disabled when no biometric/lock is enrolled.

## Design note
Biometric is enforced as a **UI gate**, not by binding Key B to user authentication. Auth-bound keys would be cryptographically stronger but break background silent re-auth and toggling the setting off. Tradeoff: at-rest protection is the non-exportable Keystore key + app sandbox + FDE. See `docs/CREDENTIALS_REAUTH.md`.

## Testing
Manually verified: enable-in-settings prompts immediately; force-stop cold start locks; quick background→foreground re-prompts; "Unlock" button works; StrictMode flood gone. **The end-to-end silent re-auth path (real token expiry → reconnect) has not yet been exercised** — worth validating before merge.

## Notes
- New deps: `androidx.biometric:biometric:1.1.0`.
- Docs: `docs/CREDENTIALS_REAUTH.md` + CLAUDE.md table row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)