### PR TITLE
feat(location): MSC3488 location sharing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,3 +163,4 @@ When investigating protocol behaviour, message shapes, or backend fields, consul
 | Element Call (WebView/WebRTC, call state, incoming banners, timeline narrator, widget protocol) | [docs/ELEMENT_CALL.md](docs/ELEMENT_CALL.md) |
 | Androlog (persistent release-safe event log, `Androlog(category, text)`, viewer screen) | [docs/ANDROLOG.md](docs/ANDROLOG.md) |
 | Message search (`search_local`/`search_server`, SearchResultsScreen, next_batch pagination) | [docs/SEARCH.md](docs/SEARCH.md) |
+| Location sharing (MSC3488, picker overlay, Geocoder search, Static Maps thumbnails, GCP setup) | [docs/LOCATION_SHARING.md](docs/LOCATION_SHARING.md) |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 
 
         // Update versionName for each release (e.g., 1.0, 1.1, 1.2, 2.0)
-        versionName = "1.0.96"
+        versionName = "1.0.97"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -170,6 +170,11 @@ dependencies {
     
     // WorkManager for periodic background tasks
     implementation("androidx.work:work-runtime-ktx:2.9.0")
+
+    // Google Maps for location sharing (MSC3488)
+    implementation("com.google.android.gms:play-services-maps:19.0.0")
+    implementation("com.google.maps.android:maps-compose:6.1.0")
+    implementation("com.google.android.gms:play-services-location:21.3.0")
     
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,10 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     
+    <!-- Location permissions for location sharing (MSC3488) -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+
     <!-- Camera permission for taking photos/videos -->
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- Microphone permission for voice/video calls -->
@@ -244,6 +248,11 @@
                 android:name="android.provider.CONTACTS_STRUCTURE"
                 android:resource="@xml/contacts" />
         </service>
+
+        <!-- Google Maps SDK API key (enable Maps SDK for Android + Maps Static API in GCP console) -->
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="@string/google_maps_api_key" />
 
         <!-- Default notification icon -->
         <meta-data

--- a/app/src/main/java/net/vrkknn/andromuks/AppViewModel.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/AppViewModel.kt
@@ -6872,6 +6872,15 @@ class AppViewModel : ViewModel() {
     
     fun updateRecentEmojis(emoji: String) = accountDataCoordinator.updateRecentEmojis(emoji)
 
+    fun sendLocationMessage(
+        roomId: String,
+        latitude: Double,
+        longitude: Double,
+        description: String = "",
+        threadRootEventId: String? = null,
+        replyToEventId: String? = null
+    ) = messageSendCoordinator.sendLocationMessage(roomId, latitude, longitude, description, threadRootEventId, replyToEventId)
+
     fun sendReply(roomId: String, text: String, originalEvent: TimelineEvent) =
         messageSendCoordinator.sendReply(roomId, text, originalEvent)
 

--- a/app/src/main/java/net/vrkknn/andromuks/BubbleTimelineScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/BubbleTimelineScreen.kt
@@ -72,6 +72,7 @@ import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Mood
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.outlined.StickyNote2
 import androidx.compose.material.icons.filled.Close
@@ -704,6 +705,7 @@ fun BubbleTimelineScreen(
     
     // Attachment menu state
     var showAttachmentMenu by remember { mutableStateOf(false) }
+    var showLocationPickerOverlay by remember { mutableStateOf(false) }
     var selectedAudioUri by remember { mutableStateOf<Uri?>(null) }
     var selectedFileUri by remember { mutableStateOf<Uri?>(null) }
     
@@ -4110,11 +4112,58 @@ fun BubbleTimelineScreen(
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                             }
+
+                            // Location option
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Surface(
+                                    color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
+                                    shape = RoundedCornerShape(16.dp),
+                                    tonalElevation = 1.dp,
+                                    modifier = Modifier.size(56.dp)
+                                ) {
+                                    IconButton(
+                                        onClick = {
+                                            showAttachmentMenu = false
+                                            showLocationPickerOverlay = true
+                                        },
+                                        modifier = Modifier.fillMaxSize()
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Filled.LocationOn,
+                                            contentDescription = "Location",
+                                            tint = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.alpha(attachmentButtonsAlpha.value)
+                                        )
+                                    }
+                                }
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = "Location",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
                         }
                     }
                     }
                 }
-                
+
+                // Location picker overlay
+                if (showLocationPickerOverlay) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        LocationPickerOverlay(
+                            onDismiss = { showLocationPickerOverlay = false },
+                            onSendLocation = { lat, lon, caption ->
+                                appViewModel.sendLocationMessage(roomId, lat, lon, description = caption)
+                                showLocationPickerOverlay = false
+                            }
+                        )
+                    }
+                }
+
                 // Floating member list for mentions
                 if (showMentionList) {
                     Box(

--- a/app/src/main/java/net/vrkknn/andromuks/LocationPickerScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/LocationPickerScreen.kt
@@ -1,0 +1,589 @@
+package net.vrkknn.andromuks
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.location.Address
+import android.location.Geocoder
+import android.location.Location
+import android.os.Build
+import android.widget.Toast
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.MyLocation
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import androidx.core.content.ContextCompat
+import coil.compose.AsyncImage
+import coil.request.CachePolicy
+import coil.request.ImageRequest
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.LatLngBounds
+import com.google.android.gms.tasks.CancellationTokenSource
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.MapEffect
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MapUiSettings
+import com.google.maps.android.compose.Marker
+import com.google.maps.android.compose.MarkerState
+import com.google.maps.android.compose.rememberCameraPositionState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import net.vrkknn.andromuks.utils.buildStaticMapUrl
+import java.util.Locale
+import kotlin.coroutines.resume
+
+private enum class LocationPickerPhase { PICKING, PREVIEW }
+
+private data class SearchResult(val displayName: String, val latLng: LatLng)
+
+private fun List<Address>.toSearchResults(): List<SearchResult> = mapNotNull { addr ->
+    if (!addr.hasLatitude() || !addr.hasLongitude()) return@mapNotNull null
+    val line0 = addr.getAddressLine(0) ?: return@mapNotNull null
+    val featureName = addr.featureName?.takeIf { it.isNotBlank() && !line0.startsWith(it) }
+    SearchResult(
+        displayName = if (featureName != null) "$featureName – $line0" else line0,
+        latLng = LatLng(addr.latitude, addr.longitude)
+    )
+}
+
+private suspend fun geocodeQuery(
+    query: String,
+    geocoder: Geocoder,
+    biasCenter: LatLng
+): List<SearchResult> = withContext(Dispatchers.IO) {
+    try {
+        // Try biased search first (±1.5° ≈ 150 km around current map center).
+        // The bounds-biased overload has no async variant, so we call it on IO regardless
+        // of API level — the deprecation only forbids calling it on the main thread.
+        val delta = 1.5
+        @Suppress("DEPRECATION")
+        val biased = geocoder.getFromLocationName(
+            query, 8,
+            biasCenter.latitude - delta, biasCenter.longitude - delta,
+            biasCenter.latitude + delta, biasCenter.longitude + delta
+        ) ?: emptyList()
+
+        if (biased.isNotEmpty()) return@withContext biased.toSearchResults()
+
+        // Nothing nearby — fall back to unbiased global search
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            suspendCancellableCoroutine { cont ->
+                geocoder.getFromLocationName(query, 8) { addresses ->
+                    cont.resume(addresses.toSearchResults())
+                }
+            }
+        } else {
+            @Suppress("DEPRECATION")
+            (geocoder.getFromLocationName(query, 8) ?: emptyList()).toSearchResults()
+        }
+    } catch (_: Exception) {
+        emptyList()
+    }
+}
+
+/**
+ * Full-screen overlay for picking and captioning a location (MSC3488).
+ * Rendered as an in-screen overlay so the room timeline stays alive.
+ *
+ * Phase 1 — PICKING: Interactive map with address/POI search (via Android Geocoder),
+ *   result markers, POI tapping, GPS jump, and a fixed center pin.
+ * Phase 2 — PREVIEW: Static map thumbnail + optional caption before sending.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LocationPickerOverlay(
+    onDismiss: () -> Unit,
+    onSendLocation: (latitude: Double, longitude: Double, caption: String) -> Unit
+) {
+    val context = LocalContext.current
+    val mapsApiKey = remember { context.getString(R.string.google_maps_api_key) }
+    val geocoder = remember { Geocoder(context, Locale.getDefault()) }
+    val focusManager = LocalFocusManager.current
+
+    var phase by remember { mutableStateOf(LocationPickerPhase.PICKING) }
+    var centerLatLng by remember { mutableStateOf(LatLng(38.7167, -9.1333)) }
+    var caption by remember { mutableStateOf("") }
+    var isLocating by remember { mutableStateOf(false) }
+
+    // Search state
+    var searchQuery by remember { mutableStateOf("") }
+    var searchResults by remember { mutableStateOf<List<SearchResult>>(emptyList()) }
+    var isSearching by remember { mutableStateOf(false) }
+    var searchFieldFocused by remember { mutableStateOf(false) }
+    val showDropdown = searchFieldFocused && searchResults.isNotEmpty()
+
+    val cameraPositionState = rememberCameraPositionState {
+        position = CameraPosition.fromLatLngZoom(centerLatLng, 14f)
+    }
+
+    // Track map center only when there are no pinned search results
+    LaunchedEffect(cameraPositionState.position) {
+        if (searchResults.isEmpty()) centerLatLng = cameraPositionState.position.target
+    }
+
+    // Debounced Geocoder search
+    LaunchedEffect(searchQuery) {
+        if (searchQuery.length < 3) {
+            searchResults = emptyList()
+            return@LaunchedEffect
+        }
+        delay(400)
+        if (!Geocoder.isPresent()) return@LaunchedEffect
+        isSearching = true
+        val results = geocodeQuery(searchQuery, geocoder, biasCenter = centerLatLng)
+        searchResults = results
+        isSearching = false
+    }
+
+    // Fit camera to show all search result markers
+    LaunchedEffect(searchResults) {
+        if (searchResults.isEmpty()) return@LaunchedEffect
+        if (searchResults.size == 1) {
+            cameraPositionState.animate(
+                CameraUpdateFactory.newLatLngZoom(searchResults[0].latLng, 15f)
+            )
+            centerLatLng = searchResults[0].latLng
+        } else {
+            val builder = LatLngBounds.Builder()
+            searchResults.forEach { builder.include(it.latLng) }
+            cameraPositionState.animate(
+                CameraUpdateFactory.newLatLngBounds(builder.build(), 120)
+            )
+        }
+    }
+
+    val fusedLocationClient = remember { LocationServices.getFusedLocationProviderClient(context) }
+
+    fun goToCurrentLocation() {
+        isLocating = true
+        val cts = CancellationTokenSource()
+        fusedLocationClient.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, cts.token)
+            .addOnSuccessListener { location: Location? ->
+                isLocating = false
+                if (location != null) {
+                    val ll = LatLng(location.latitude, location.longitude)
+                    centerLatLng = ll
+                    cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(ll, 16f))
+                } else {
+                    Toast.makeText(context, "Could not get current location", Toast.LENGTH_SHORT).show()
+                }
+            }
+            .addOnFailureListener {
+                isLocating = false
+                Toast.makeText(context, "Location unavailable", Toast.LENGTH_SHORT).show()
+            }
+    }
+
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val granted = permissions[Manifest.permission.ACCESS_FINE_LOCATION] == true ||
+                permissions[Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        if (granted) goToCurrentLocation()
+        else Toast.makeText(context, "Location permission denied", Toast.LENGTH_SHORT).show()
+    }
+
+    fun requestLocationAndGo() {
+        val granted = ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.ACCESS_COARSE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED
+        if (granted) goToCurrentLocation()
+        else locationPermissionLauncher.launch(
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION)
+        )
+    }
+
+    LaunchedEffect(Unit) {
+        val hasPermission = ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(
+                    context, Manifest.permission.ACCESS_COARSE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED
+        if (hasPermission) goToCurrentLocation()
+    }
+
+    BackHandler {
+        when {
+            showDropdown -> { focusManager.clearFocus(); searchResults = emptyList() }
+            phase == LocationPickerPhase.PREVIEW -> phase = LocationPickerPhase.PICKING
+            else -> onDismiss()
+        }
+    }
+
+    val hasLocationPermission = ContextCompat.checkSelfPermission(
+        context, Manifest.permission.ACCESS_FINE_LOCATION
+    ) == PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.ACCESS_COARSE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+
+    fun selectResult(result: SearchResult) {
+        centerLatLng = result.latLng
+        cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(result.latLng, 15f))
+        searchQuery = result.displayName
+        focusManager.clearFocus()
+        searchResults = emptyList()
+    }
+
+    when (phase) {
+        LocationPickerPhase.PICKING -> {
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        title = { Text("Share Location") },
+                        navigationIcon = {
+                            IconButton(onClick = onDismiss) {
+                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                            }
+                        }
+                    )
+                },
+                floatingActionButton = {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        horizontalAlignment = Alignment.End
+                    ) {
+                        SmallFloatingActionButton(
+                            onClick = { requestLocationAndGo() },
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer
+                        ) {
+                            if (isLocating) {
+                                CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                            } else {
+                                Icon(Icons.Filled.MyLocation, contentDescription = "My location")
+                            }
+                        }
+                        ExtendedFloatingActionButton(
+                            onClick = {
+                                focusManager.clearFocus()
+                                phase = LocationPickerPhase.PREVIEW
+                            },
+                            icon = { Icon(Icons.AutoMirrored.Filled.Send, contentDescription = null) },
+                            text = { Text("Use this location") }
+                        )
+                    }
+                }
+            ) { paddingValues ->
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                ) {
+                    // POI click via MapEffect (onPoiClick removed from GoogleMap params in maps-compose 4+)
+                    var pendingPoi by remember {
+                        mutableStateOf<com.google.android.gms.maps.model.PointOfInterest?>(null)
+                    }
+                    LaunchedEffect(pendingPoi) {
+                        val poi = pendingPoi ?: return@LaunchedEffect
+                        centerLatLng = poi.latLng
+                        cameraPositionState.move(CameraUpdateFactory.newLatLngZoom(poi.latLng, 16f))
+                        searchQuery = poi.name
+                        focusManager.clearFocus()
+                        searchResults = emptyList()
+                        pendingPoi = null
+                    }
+
+                    GoogleMap(
+                        modifier = Modifier.fillMaxSize(),
+                        cameraPositionState = cameraPositionState,
+                        uiSettings = MapUiSettings(
+                            zoomControlsEnabled = true,
+                            myLocationButtonEnabled = false,
+                            compassEnabled = true
+                        ),
+                        properties = MapProperties(isMyLocationEnabled = hasLocationPermission),
+                        onMapClick = {
+                            focusManager.clearFocus()
+                            searchResults = emptyList()
+                            searchQuery = ""
+                        }
+                    ) {
+                        MapEffect { map ->
+                            map.setOnPoiClickListener { poi -> pendingPoi = poi }
+                        }
+
+                        // Search result markers
+                        searchResults.forEach { result ->
+                            Marker(
+                                state = MarkerState(position = result.latLng),
+                                title = result.displayName.substringBefore(" – "),
+                                snippet = result.displayName.substringAfter(" – ", ""),
+                                onClick = { selectResult(result); true }
+                            )
+                        }
+                    }
+
+                    // Center pin — shows the currently selected send location
+                    // Hidden while multiple results are shown (user hasn't chosen one yet)
+                    if (searchResults.size <= 1) {
+                        Icon(
+                            imageVector = Icons.Filled.LocationOn,
+                            contentDescription = null,
+                            tint = MaterialTheme.colorScheme.primary,
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .size(40.dp)
+                                .offset(y = (-20).dp) // pin tip at center
+                        )
+                    }
+
+                    // Floating search card + results dropdown
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 8.dp)
+                            .zIndex(1f)
+                    ) {
+                        Card(
+                            shape = RoundedCornerShape(28.dp),
+                            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                            colors = CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                            )
+                        ) {
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp, vertical = 4.dp),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            ) {
+                                if (isSearching) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(20.dp),
+                                        strokeWidth = 2.dp
+                                    )
+                                } else {
+                                    Icon(
+                                        Icons.Filled.Search,
+                                        contentDescription = null,
+                                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        modifier = Modifier.size(20.dp)
+                                    )
+                                }
+                                TextField(
+                                    value = searchQuery,
+                                    onValueChange = { searchQuery = it },
+                                    placeholder = { Text("Search address or place…") },
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .onFocusChanged { searchFieldFocused = it.isFocused },
+                                    singleLine = true,
+                                    colors = TextFieldDefaults.colors(
+                                        focusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                                        unfocusedContainerColor = androidx.compose.ui.graphics.Color.Transparent,
+                                        focusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent,
+                                        unfocusedIndicatorColor = androidx.compose.ui.graphics.Color.Transparent
+                                    ),
+                                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                                    keyboardActions = KeyboardActions(
+                                        onSearch = { focusManager.clearFocus() }
+                                    )
+                                )
+                                if (searchQuery.isNotEmpty()) {
+                                    IconButton(
+                                        onClick = {
+                                            searchQuery = ""
+                                            searchResults = emptyList()
+                                        },
+                                        modifier = Modifier.size(24.dp)
+                                    ) {
+                                        Icon(
+                                            Icons.Filled.Clear,
+                                            contentDescription = "Clear",
+                                            modifier = Modifier.size(18.dp)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                        // Dropdown list of results
+                        if (showDropdown) {
+                            Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 4.dp),
+                                shape = RoundedCornerShape(16.dp),
+                                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.surfaceContainerHigh
+                                )
+                            ) {
+                                LazyColumn {
+                                    itemsIndexed(searchResults) { index, result ->
+                                        ListItem(
+                                            headlineContent = {
+                                                val parts = result.displayName.split(" – ", limit = 2)
+                                                if (parts.size == 2) {
+                                                    Column {
+                                                        Text(parts[0], style = MaterialTheme.typography.bodyMedium)
+                                                        Text(
+                                                            parts[1],
+                                                            style = MaterialTheme.typography.bodySmall,
+                                                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                                                        )
+                                                    }
+                                                } else {
+                                                    Text(result.displayName, style = MaterialTheme.typography.bodyMedium, maxLines = 2)
+                                                }
+                                            },
+                                            leadingContent = {
+                                                Icon(
+                                                    Icons.Filled.LocationOn,
+                                                    contentDescription = null,
+                                                    tint = MaterialTheme.colorScheme.primary,
+                                                    modifier = Modifier.size(20.dp)
+                                                )
+                                            },
+                                            modifier = Modifier.clickable { selectResult(result) }
+                                        )
+                                        if (index < searchResults.lastIndex) {
+                                            HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Coordinate readout — only when not showing the dropdown
+                    if (!showDropdown && searchResults.size <= 1) {
+                        Surface(
+                            modifier = Modifier
+                                .align(Alignment.BottomCenter)
+                                .padding(bottom = 88.dp),
+                            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+                            shape = MaterialTheme.shapes.medium,
+                            tonalElevation = 4.dp
+                        ) {
+                            Text(
+                                text = "%.6f, %.6f".format(centerLatLng.latitude, centerLatLng.longitude),
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        LocationPickerPhase.PREVIEW -> {
+            val staticMapUrl = remember(centerLatLng, mapsApiKey) {
+                buildStaticMapUrl(centerLatLng.latitude, centerLatLng.longitude, mapsApiKey)
+            }
+            val imageRequest = remember(staticMapUrl) {
+                ImageRequest.Builder(context)
+                    .data(staticMapUrl)
+                    .memoryCachePolicy(CachePolicy.ENABLED)
+                    .diskCachePolicy(CachePolicy.ENABLED)
+                    .build()
+            }
+
+            Scaffold(
+                topBar = {
+                    TopAppBar(
+                        title = { Text("Send Location") },
+                        navigationIcon = {
+                            IconButton(onClick = { phase = LocationPickerPhase.PICKING }) {
+                                Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                            }
+                        },
+                        actions = {
+                            IconButton(
+                                onClick = {
+                                    onSendLocation(
+                                        centerLatLng.latitude,
+                                        centerLatLng.longitude,
+                                        caption.trim()
+                                    )
+                                }
+                            ) {
+                                Icon(Icons.AutoMirrored.Filled.Send, contentDescription = "Send")
+                            }
+                        }
+                    )
+                }
+            ) { paddingValues ->
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(paddingValues)
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    AsyncImage(
+                        model = imageRequest,
+                        contentDescription = "Location preview",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(220.dp)
+                            .clip(RoundedCornerShape(16.dp))
+                    )
+
+                    Text(
+                        text = if (searchQuery.isNotBlank()) searchQuery
+                        else "%.6f, %.6f".format(centerLatLng.latitude, centerLatLng.longitude),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+
+                    OutlinedTextField(
+                        value = caption,
+                        onValueChange = { caption = it },
+                        label = { Text("Caption (optional)") },
+                        placeholder = { Text("Add a description…") },
+                        modifier = Modifier.fillMaxWidth(),
+                        singleLine = true,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                        keyboardActions = KeyboardActions(
+                            onSend = {
+                                onSendLocation(
+                                    centerLatLng.latitude,
+                                    centerLatLng.longitude,
+                                    caption.trim()
+                                )
+                            }
+                        )
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/net/vrkknn/andromuks/MessageSendCoordinator.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/MessageSendCoordinator.kt
@@ -730,6 +730,63 @@ internal class MessageSendCoordinator(
         }
     }
 
+    fun sendLocationMessage(
+        roomId: String,
+        latitude: Double,
+        longitude: Double,
+        description: String = "",
+        threadRootEventId: String? = null,
+        replyToEventId: String? = null
+    ) {
+        notifyUserSentTo(roomId)
+        val messageRequestId = vm.getAndIncrementRequestId()
+        vm.trackOutgoingRequest(messageRequestId, roomId)
+
+        val geoUri = "geo:$latitude,$longitude"
+
+        val baseContent = mapOf(
+            "msgtype" to "m.location",
+            "body" to if (description.isNotBlank()) description else "Location",
+            "geo_uri" to geoUri
+        )
+
+        val extra = mapOf(
+            "org.matrix.msc3488.asset" to mapOf("type" to "m.pin"),
+            "org.matrix.msc3488.location" to mapOf(
+                "uri" to geoUri,
+                "description" to description
+            )
+        )
+
+        val dataMap = mutableMapOf<String, Any>(
+            "room_id" to roomId,
+            "base_content" to baseContent,
+            "extra" to extra,
+            "text" to "",
+            "mentions" to mapOf("user_ids" to emptyList<String>(), "room" to false),
+            "url_previews" to emptyList<Any>()
+        )
+
+        if (threadRootEventId != null) {
+            val resolvedReplyTarget = replyToEventId
+                ?: vm.getThreadMessages(roomId, threadRootEventId).lastOrNull()?.eventId
+            val threadFallbackFlag = resolvedReplyTarget == null
+            val relatesTo = mutableMapOf<String, Any>(
+                "rel_type" to "m.thread",
+                "event_id" to threadRootEventId,
+                "is_falling_back" to threadFallbackFlag
+            )
+            if (resolvedReplyTarget != null) {
+                relatesTo["m.in_reply_to"] = mapOf("event_id" to resolvedReplyTarget)
+            }
+            dataMap["relates_to"] = relatesTo
+        }
+
+        vm.sendWebSocketCommand("send_message", messageRequestId, dataMap)
+        vm.messageRequests[messageRequestId] = roomId
+        vm.pendingSendCount++
+    }
+
     fun sendVideoMessage(
         roomId: String,
         videoMxcUrl: String,

--- a/app/src/main/java/net/vrkknn/andromuks/RoomTimelineScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/RoomTimelineScreen.kt
@@ -97,6 +97,7 @@ import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Mood
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
@@ -1027,6 +1028,8 @@ fun RoomTimelineScreen(
     
     // Attachment menu state
     var showAttachmentMenu by remember { mutableStateOf(false) }
+    // Location picker overlay — shown instead of navigating so the room stays alive
+    var showLocationPickerOverlay by remember { mutableStateOf(false) }
     // In-app camera snapping overlay (rememberSaveable so it survives rotation/config changes)
     var showCameraOverlay by rememberSaveable { mutableStateOf(false) }
     // Simple flash mode cycling for CameraX integration
@@ -3131,11 +3134,13 @@ fun RoomTimelineScreen(
     val isBackStackEmpty = remember { navController.previousBackStackEntry == null }
     val isRootDestination = isBackStackEmpty
     BackHandler(
-        enabled = messageMenuConfig != null || showCameraOverlay || showVideoOverlay ||
+        enabled = messageMenuConfig != null || showLocationPickerOverlay || showCameraOverlay || showVideoOverlay ||
                 showAttachmentMenu || jumpBackStack.isNotEmpty() || isRootDestination
     ) {
         if (messageMenuConfig != null) {
             messageMenuConfig = null
+        } else if (showLocationPickerOverlay) {
+            showLocationPickerOverlay = false
         } else if (showCameraOverlay) {
             showCameraOverlay = false
         } else if (showVideoOverlay) {
@@ -4431,6 +4436,19 @@ fun RoomTimelineScreen(
                 }
                 }
                 
+                // Location picker overlay — shown without navigation so the room stays alive
+                if (showLocationPickerOverlay) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        LocationPickerOverlay(
+                            onDismiss = { showLocationPickerOverlay = false },
+                            onSendLocation = { lat, lon, caption ->
+                                appViewModel.sendLocationMessage(roomId, lat, lon, description = caption)
+                                showLocationPickerOverlay = false
+                            }
+                        )
+                    }
+                }
+
                 // In-app camera snapping overlay (full-frame between header and message box)
                 AnimatedVisibility(
                     visible = showCameraOverlay,
@@ -5223,6 +5241,40 @@ fun RoomTimelineScreen(
                                 Spacer(modifier = Modifier.height(4.dp))
                                 Text(
                                     text = "Video",
+                                    style = MaterialTheme.typography.labelSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+
+                            // Location option
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                modifier = Modifier.weight(1f)
+                            ) {
+                                Surface(
+                                    color = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
+                                    shape = RoundedCornerShape(16.dp),
+                                    tonalElevation = 1.dp,
+                                    modifier = Modifier.size(56.dp)
+                                ) {
+                                    IconButton(
+                                        onClick = {
+                                            showAttachmentMenu = false
+                                            showLocationPickerOverlay = true
+                                        },
+                                        modifier = Modifier.fillMaxSize()
+                                    ) {
+                                        Icon(
+                                            imageVector = Icons.Filled.LocationOn,
+                                            contentDescription = "Location",
+                                            tint = MaterialTheme.colorScheme.primary,
+                                            modifier = Modifier.alpha(attachmentButtonsAlpha.value)
+                                        )
+                                    }
+                                }
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Text(
+                                    text = "Location",
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )

--- a/app/src/main/java/net/vrkknn/andromuks/ThreadViewerScreen.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/ThreadViewerScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.material.icons.filled.AudioFile
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Videocam
+import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.CloudOff
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.outlined.StickyNote2
@@ -400,6 +401,7 @@ fun ThreadViewerScreen(
 
     // Attachment/media state
     var showAttachmentMenu by remember { mutableStateOf(false) }
+    var showLocationPickerOverlay by remember { mutableStateOf(false) }
     var selectedMediaUri by remember { mutableStateOf<android.net.Uri?>(null) }
     var selectedAudioUri by remember { mutableStateOf<android.net.Uri?>(null) }
     var selectedFileUri by remember { mutableStateOf<android.net.Uri?>(null) }
@@ -2394,11 +2396,44 @@ fun ThreadViewerScreen(
                                     modifier = Modifier.alpha(attachmentButtonsAlpha.value)
                                 )
                             }
+                            IconButton(
+                                onClick = {
+                                    showAttachmentMenu = false
+                                    showLocationPickerOverlay = true
+                                },
+                                modifier = Modifier.size(56.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Filled.LocationOn,
+                                    contentDescription = "Location",
+                                    tint = MaterialTheme.colorScheme.primary,
+                                    modifier = Modifier.alpha(attachmentButtonsAlpha.value)
+                                )
+                            }
                         }
                     }
                 }
                 }
-                
+
+                // Location picker overlay
+                if (showLocationPickerOverlay) {
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        LocationPickerOverlay(
+                            onDismiss = { showLocationPickerOverlay = false },
+                            onSendLocation = { lat, lon, caption ->
+                                appViewModel.sendLocationMessage(
+                                    roomId = roomId,
+                                    latitude = lat,
+                                    longitude = lon,
+                                    description = caption,
+                                    threadRootEventId = threadRootEventId
+                                )
+                                showLocationPickerOverlay = false
+                            }
+                        )
+                    }
+                }
+
                 // Emoji shortcode suggestion list
                 if (showEmojiSuggestionList) {
                     Box(

--- a/app/src/main/java/net/vrkknn/andromuks/TimelineEventItem.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/TimelineEventItem.kt
@@ -99,6 +99,8 @@ import net.vrkknn.andromuks.utils.mediaBubbleColorFor
 import net.vrkknn.andromuks.utils.stickerBubbleColorFor
 import net.vrkknn.andromuks.utils.BubblePalette
 import net.vrkknn.andromuks.utils.BubbleColors
+import net.vrkknn.andromuks.utils.LocationMessageContent
+import net.vrkknn.andromuks.utils.parseGeoUri
 import net.vrkknn.andromuks.BuildConfig
 
 import java.text.SimpleDateFormat
@@ -1206,6 +1208,39 @@ private fun RoomMessageContent(
         return
     }
     
+    // Check if it's a location message (MSC3488 / m.location)
+    if (finalMsgType == "m.location") {
+        RoomLocationMessageContent(
+            event = event,
+            content = content,
+            body = finalBody,
+            actualIsMine = actualIsMine,
+            mentionsMe = mentionsMe,
+            isRedacted = isRedacted,
+            userProfileCache = userProfileCache,
+            replyInfo = replyInfo,
+            originalEvent = originalEvent,
+            timelineEvents = timelineEvents,
+            homeserverUrl = homeserverUrl,
+            authToken = authToken,
+            isConsecutive = isConsecutive,
+            displayName = displayName,
+            avatarUrl = avatarUrl,
+            readReceipts = readReceipts,
+            appViewModel = appViewModel,
+            myUserId = myUserId,
+            onScrollToMessage = onScrollToMessage,
+            onReply = onReply,
+            onReact = onReact,
+            onDelete = onDelete,
+            onUserClick = onUserClick,
+            onThreadClick = onThreadClick,
+            onShowMenu = onShowMenu,
+            onShowReactions = onShowReactions
+        )
+        return
+    }
+
     // Check if it's a media message
     if (msgType == "m.image" || msgType == "m.video" || msgType == "m.audio" || msgType == "m.file") {
         RoomMediaMessageContent(
@@ -1269,6 +1304,175 @@ private fun RoomMessageContent(
             onShowMenu = onShowMenu,
             onShowReactions = onShowReactions
         )
+    }
+}
+
+@Composable
+private fun RoomLocationMessageContent(
+    event: TimelineEvent,
+    content: org.json.JSONObject?,
+    body: String,
+    actualIsMine: Boolean,
+    mentionsMe: Boolean,
+    isRedacted: Boolean,
+    userProfileCache: Map<String, MemberProfile>,
+    replyInfo: ReplyInfo?,
+    originalEvent: TimelineEvent?,
+    timelineEvents: List<TimelineEvent>,
+    homeserverUrl: String,
+    authToken: String,
+    isConsecutive: Boolean,
+    displayName: String?,
+    avatarUrl: String?,
+    readReceipts: List<ReadReceipt>,
+    appViewModel: AppViewModel?,
+    myUserId: String?,
+    onScrollToMessage: (String) -> Unit,
+    onReply: (TimelineEvent) -> Unit,
+    onReact: (TimelineEvent) -> Unit,
+    onDelete: (TimelineEvent) -> Unit,
+    onUserClick: (String) -> Unit,
+    onThreadClick: (TimelineEvent) -> Unit,
+    onShowMenu: ((MessageMenuConfig) -> Unit)? = null,
+    onShowReactions: (() -> Unit)? = null
+) {
+    val geoUri = content?.optString("geo_uri", "") ?: ""
+    val coords = remember(geoUri) { parseGeoUri(geoUri) }
+
+    val bubbleShape = if (actualIsMine) {
+        RoundedCornerShape(topStart = 12.dp, topEnd = 2.dp, bottomEnd = 12.dp, bottomStart = 12.dp)
+    } else {
+        RoundedCornerShape(topStart = 2.dp, topEnd = 12.dp, bottomEnd = 12.dp, bottomStart = 12.dp)
+    }
+
+    val bubbleColors = if (isRedacted) {
+        BubblePalette.colors(MaterialTheme.colorScheme, isMine = actualIsMine, isRedacted = true)
+    } else {
+        BubblePalette.colors(MaterialTheme.colorScheme, isMine = actualIsMine)
+    }
+
+    val mapsApiKey = androidx.compose.ui.platform.LocalContext.current
+        .getString(net.vrkknn.andromuks.R.string.google_maps_api_key)
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // Sender header (non-consecutive)
+        if (!isConsecutive && !actualIsMine) {
+            Row(
+                modifier = Modifier.padding(start = 4.dp, bottom = 2.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                net.vrkknn.andromuks.ui.components.AvatarImage(
+                    mxcUrl = avatarUrl,
+                    homeserverUrl = homeserverUrl,
+                    authToken = authToken,
+                    fallbackText = displayName ?: event.sender,
+                    modifier = Modifier
+                        .size(28.dp)
+                        .clickable { onUserClick(event.sender) }
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = displayName ?: event.sender,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.clickable { onUserClick(event.sender) }
+                )
+            }
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = if (actualIsMine) Arrangement.End else Arrangement.Start
+        ) {
+            MessageBubbleWithMenu(
+                event = event,
+                bubbleColor = bubbleColors.container,
+                bubbleShape = bubbleShape,
+                modifier = Modifier.widthIn(max = 280.dp).padding(top = 2.dp),
+                isMine = actualIsMine,
+                myUserId = myUserId,
+                powerLevels = appViewModel?.currentRoomState?.powerLevels,
+                onReply = { onReply(event) },
+                onReact = { onReact(event) },
+                onEdit = {},
+                onDelete = { onDelete(event) },
+                appViewModel = appViewModel,
+                onBubbleClick = { onThreadClick(event) },
+                onShowEditHistory = null,
+                onShowMenu = onShowMenu,
+                mentionBorder = bubbleColors.mentionBorder,
+                threadBorder = bubbleColors.threadBorder,
+                onShowReactions = onShowReactions
+            ) {
+                if (isRedacted) {
+                    val deletionMessage = net.vrkknn.andromuks.utils.RedactionUtils.createDeletionMessage(
+                        event.redactionSender, event.redactionReason, event.redactionTimestamp, userProfileCache
+                    )
+                    Text(
+                        text = deletionMessage,
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = bubbleColors.content,
+                        fontStyle = FontStyle.Italic,
+                        modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp)
+                    )
+                } else {
+                    LocationMessageContent(
+                        geoUri = geoUri,
+                        body = body,
+                        mapsApiKey = mapsApiKey,
+                        contentColor = bubbleColors.content,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+
+        // Read receipts
+        if (readReceipts.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 2.dp),
+                horizontalArrangement = if (actualIsMine) Arrangement.End else Arrangement.Start
+            ) {
+                net.vrkknn.andromuks.utils.AnimatedInlineReadReceiptAvatars(
+                    receipts = readReceipts,
+                    userProfileCache = userProfileCache,
+                    homeserverUrl = homeserverUrl,
+                    authToken = authToken,
+                    appViewModel = appViewModel,
+                    messageSender = event.sender,
+                    eventId = event.eventId,
+                    isMine = actualIsMine
+                )
+            }
+        }
+
+        // Reaction badges
+        if (appViewModel != null) {
+            val reactions = remember(appViewModel.reactionUpdateCounter, event.eventId) {
+                appViewModel.messageReactions[event.eventId] ?: emptyList()
+            }
+            if (reactions.isNotEmpty()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 2.dp),
+                    horizontalArrangement = if (actualIsMine) Arrangement.End else Arrangement.Start
+                ) {
+                    ReactionBadges(
+                        eventId = event.eventId,
+                        reactions = reactions,
+                        homeserverUrl = homeserverUrl,
+                        authToken = authToken,
+                        isMine = actualIsMine,
+                        onReactionClick = { emoji ->
+                            appViewModel.sendReaction(event.roomId, event.eventId, emoji)
+                        }
+                    )
+                }
+            }
+        }
     }
 }
 

--- a/app/src/main/java/net/vrkknn/andromuks/utils/LocationMessageContent.kt
+++ b/app/src/main/java/net/vrkknn/andromuks/utils/LocationMessageContent.kt
@@ -1,0 +1,150 @@
+package net.vrkknn.andromuks.utils
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.OpenInNew
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import coil.request.CachePolicy
+import coil.request.ImageRequest
+
+/**
+ * Parses a geo URI (geo:lat,lon or geo:lat,lon;u=accuracy or geo:lat,lon,alt) into
+ * a (latitude, longitude) pair, or returns null if the URI is not valid.
+ */
+fun parseGeoUri(geoUri: String): Pair<Double, Double>? {
+    if (!geoUri.startsWith("geo:")) return null
+    val coords = geoUri.removePrefix("geo:").split(";").first().split(",")
+    return try {
+        val lat = coords[0].toDouble()
+        val lon = coords[1].toDouble()
+        Pair(lat, lon)
+    } catch (_: Exception) {
+        null
+    }
+}
+
+/**
+ * Builds a Google Maps Static API thumbnail URL for a lat/lon pin.
+ * Requires the Maps Static API to be enabled in GCP console for the provided key.
+ */
+fun buildStaticMapUrl(latitude: Double, longitude: Double, apiKey: String): String {
+    val marker = "color:red|$latitude,$longitude"
+    return "https://maps.googleapis.com/maps/api/staticmap" +
+            "?center=$latitude,$longitude" +
+            "&zoom=14" +
+            "&size=400x200" +
+            "&markers=${Uri.encode(marker)}" +
+            "&key=$apiKey"
+}
+
+/**
+ * Renders a location message bubble (m.location / MSC3488).
+ *
+ * Shows a Google Maps Static API thumbnail (loaded by Coil) with the coordinates
+ * and a tap target that opens the location in the system maps app.
+ *
+ * @param contentColor The text/icon color — pass the bubble's content color so it
+ *   always contrasts with the bubble background regardless of theme or sender.
+ */
+@Composable
+fun LocationMessageContent(
+    geoUri: String,
+    body: String,
+    mapsApiKey: String,
+    contentColor: androidx.compose.ui.graphics.Color,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val coords = remember(geoUri) { parseGeoUri(geoUri) }
+
+    val openInMaps = {
+        if (coords != null) {
+            val mapsUri = Uri.parse("geo:${coords.first},${coords.second}?q=${coords.first},${coords.second}")
+            val intent = Intent(Intent.ACTION_VIEW, mapsUri)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            try {
+                context.startActivity(intent)
+            } catch (_: Exception) {
+                val webUri = Uri.parse("https://maps.google.com/?q=${coords.first},${coords.second}")
+                context.startActivity(Intent(Intent.ACTION_VIEW, webUri).apply {
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                })
+            }
+        }
+    }
+
+    Column(modifier = modifier.width(IntrinsicSize.Min)) {
+        if (coords != null) {
+            val staticMapUrl = remember(coords, mapsApiKey) {
+                buildStaticMapUrl(coords.first, coords.second, mapsApiKey)
+            }
+            val imageRequest = remember(staticMapUrl) {
+                ImageRequest.Builder(context)
+                    .data(staticMapUrl)
+                    .memoryCachePolicy(CachePolicy.ENABLED)
+                    .diskCachePolicy(CachePolicy.ENABLED)
+                    .build()
+            }
+            AsyncImage(
+                model = imageRequest,
+                contentDescription = "Map showing location",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(160.dp)
+                    .clip(RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp))
+                    .clickable { openInMaps() }
+            )
+        }
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { openInMaps() }
+                .padding(horizontal = 10.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Icon(
+                imageVector = Icons.Filled.LocationOn,
+                contentDescription = null,
+                tint = contentColor,
+                modifier = Modifier.size(18.dp)
+            )
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = if (body.isNotBlank() && body != "Location") body else "Location",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = contentColor
+                )
+                if (coords != null) {
+                    Text(
+                        text = "%.5f, %.5f".format(coords.first, coords.second),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = contentColor.copy(alpha = 0.7f)
+                    )
+                }
+            }
+            Icon(
+                imageVector = Icons.Filled.OpenInNew,
+                contentDescription = "Open in Maps",
+                tint = contentColor.copy(alpha = 0.6f),
+                modifier = Modifier.size(16.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Andromuks</string>
+    <string name="google_maps_api_key">AIzaSyAAGwca7l1BN9uatWbC3TsYrPphjdVb4BA</string>
 </resources>

--- a/docs/LOCATION_SHARING.md
+++ b/docs/LOCATION_SHARING.md
@@ -1,0 +1,107 @@
+# Location Sharing (MSC3488)
+
+Location sharing is implemented per [MSC3488](https://github.com/matrix-org/matrix-spec-proposals/blob/matthew/location/proposals/3488-location.md).
+
+---
+
+## Sending a location
+
+### Wire format
+
+Locations are sent as `m.room.message` events with `msgtype: m.location`, plus MSC3488 extension fields in the `extra` map of the `send_message` command:
+
+```json
+{
+  "command": "send_message",
+  "data": {
+    "room_id": "!room:server",
+    "base_content": {
+      "msgtype": "m.location",
+      "body": "Optional caption",
+      "geo_uri": "geo:41.151,-8.609"
+    },
+    "extra": {
+      "org.matrix.msc3488.asset": { "type": "m.pin" },
+      "org.matrix.msc3488.location": {
+        "uri": "geo:41.151,-8.609",
+        "description": "Optional caption"
+      }
+    },
+    "text": "",
+    "mentions": { "user_ids": [], "room": false },
+    "url_previews": []
+  }
+}
+```
+
+`body` and `org.matrix.msc3488.location.description` are set to the user-supplied caption, or left as `"Location"` / `""` when no caption is given.
+
+### Code path
+
+`MessageSendCoordinator.sendLocationMessage()` → `AppViewModel.sendLocationMessage()` → called from each screen's `LocationPickerOverlay` `onSendLocation` callback.
+
+---
+
+## UI — Location picker overlay
+
+The picker is a two-phase full-screen overlay (`LocationPickerOverlay` in `LocationPickerScreen.kt`). It is rendered as an in-screen `Box` overlay rather than a separate nav destination, so the room timeline stays composed (and the WebSocket room subscription remains active) while the picker is open.
+
+### Phase 1 — PICKING
+
+- **Interactive Google Map** (`maps-compose`) with a fixed centre-pin that tracks the camera position. The user pan/zooms to position the pin.
+- **Address / POI search** using `android.location.Geocoder` (no API key, uses Play Services). Search is debounced 400 ms. Results are shown both as a dropdown list and as `Marker` composables on the map. The camera animates to fit all result markers (`LatLngBounds`).
+- **Location bias**: the Geocoder bounds-biased overload (`getFromLocationName(query, n, south, west, north, east)`) is called first with a ±1.5° box around the current map centre. Falls back to unbiased global search only if no local results are found.
+- **POI tapping**: `map.setOnPoiClickListener` (set via `MapEffect` — `onPoiClick` was removed from `GoogleMap` composable params in maps-compose 4+) moves the camera to the tapped POI and populates the search field with the POI name.
+- **GPS button**: jumps camera to the device's current GPS fix via `FusedLocationProviderClient`. Fires automatically on first open if `ACCESS_FINE_LOCATION` or `ACCESS_COARSE_LOCATION` is granted.
+
+### Phase 2 — PREVIEW
+
+- Shows a **Google Maps Static API** thumbnail (loaded by Coil, cached to disk) of the chosen location.
+- Displays the search query / POI name (or raw coordinates as fallback).
+- **Caption text field** — typed value becomes both `body` and `org.matrix.msc3488.location.description` in the sent event.
+- Send button in the top-right (or keyboard IME `Send` action) calls `onSendLocation`.
+
+---
+
+## UI — Rendering received locations
+
+`m.location` events (detected by `msgType == "m.location"` in `RoomMessageContent`) are rendered by `RoomLocationMessageContent` in `TimelineEventItem.kt`, which wraps `LocationMessageContent` (`utils/LocationMessageContent.kt`) inside the standard `MessageBubbleWithMenu`.
+
+`LocationMessageContent`:
+- Loads a **Google Maps Static API** thumbnail via Coil (`buildStaticMapUrl(lat, lon, apiKey)`).
+- Displays the `body` (caption) and coordinates below the thumbnail.
+- Tapping opens `geo:` URI → any installed maps app; falls back to `maps.google.com`.
+- Receives `contentColor` from the bubble palette (`bubbleColors.content`) so text always contrasts with the bubble background regardless of sender or theme.
+
+---
+
+## GCP setup required
+
+| API | Used for |
+|-----|----------|
+| Maps SDK for Android | Interactive map in the picker |
+| Maps Static API | Thumbnails in the picker preview and in the timeline |
+| *(Geocoding API not needed)* | Search uses `android.location.Geocoder` via Play Services |
+
+The Maps API key is stored in `app/src/main/res/values/strings.xml` as `google_maps_api_key` and referenced in `AndroidManifest.xml` via `com.google.android.geo.API_KEY`. The key must have an **Android app restriction** with the app's package name and signing certificate SHA-1 registered.
+
+---
+
+## Permissions
+
+```xml
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+```
+
+Both are requested at runtime (via `rememberLauncherForActivityResult`) when the user taps the GPS button. The map and search work without location permission; only GPS jump and the `isMyLocationEnabled` blue-dot layer need it.
+
+---
+
+## Screens that support sending locations
+
+| Screen | Overlay state var | Thread support |
+|--------|------------------|----------------|
+| `RoomTimelineScreen` | `showLocationPickerOverlay` | No (room-level only) |
+| `BubbleTimelineScreen` | `showLocationPickerOverlay` | No |
+| `ThreadViewerScreen` | `showLocationPickerOverlay` | Yes — passes `threadRootEventId` to `sendLocationMessage` |


### PR DESCRIPTION
## Summary

- **Send** `m.location` events (MSC3488) with `geo_uri`, asset pin, and optional caption via `MessageSendCoordinator.sendLocationMessage()`
- **Render** received location events in the timeline as a Google Maps Static API thumbnail with caption, coordinates, and tap-to-open-maps; text colour uses the bubble palette for correct contrast in both light/dark themes and own/other bubbles
- **Pick** via a two-phase full-screen overlay (`LocationPickerOverlay`) that keeps the room timeline alive (no nav destination):
  - Phase 1: interactive Google Map with address/POI search (Android Geocoder, ±1.5° location bias + global fallback), result markers on map with `LatLngBounds` camera fit, POI tap via `MapEffect`, GPS jump with permission handling
  - Phase 2: Static API thumbnail preview + optional caption input before send
- Location button added to attachment menu in `RoomTimelineScreen`, `BubbleTimelineScreen`, and `ThreadViewerScreen` (thread-aware)
- New permissions: `ACCESS_FINE_LOCATION`, `ACCESS_COARSE_LOCATION`
- New dependencies: `play-services-maps`, `maps-compose:6.1.0`, `play-services-location`
- `docs/LOCATION_SHARING.md` added with GCP setup instructions

## Test plan

- [ ] Send a location from RoomTimelineScreen — verify event appears with map thumbnail and correct bubble text colour for both own and received messages
- [ ] Send from ThreadViewerScreen — verify `threadRootEventId` is included in the sent event
- [ ] Search "Torre dos Clérigos" — verify results are biased to Portugal, not Nicaragua
- [ ] Search "mcdonalds porto" — verify multiple markers appear on map and camera fits all
- [ ] Tap a map POI — verify camera moves and search field populates
- [ ] GPS button — verify permission prompt then map jump
- [ ] Tap a location message in timeline — verify system maps app opens
- [ ] Deny location permission — verify map and search still work, only GPS button fails gracefully
- [ ] Verify no room disposal (WebSocket stays connected) when picker opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)